### PR TITLE
DRY out deployment and config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,39 @@
 version: 2
 
 references:
+  set_environment_variables: &set_environment_variables
+    run:
+      name: Set Environment Variables
+      command: |
+        echo 'export CI_SHA1=$CIRCLE_SHA1' >> ${BASH_ENV}
+        echo 'export CI_BRANCH=$CIRCLE_BRANCH' >> ${BASH_ENV}
+        echo 'export CI_BUILD_NUM=$CIRCLE_BUILD_NUM' >> ${BASH_ENV}
+        echo 'export CI_TAG=$CIRCLE_TAG' >> ${BASH_ENV}
+        echo 'export EXTERNAL_REGISTRY_BASE_DOMAIN=quay.io' >> ${BASH_ENV}
+        echo 'export DOCKERFILE=Dockerfile' >> ${BASH_ENV}
+        echo 'export REPOSITORY_NAME=reactiveops/fairwinds' >> ${BASH_ENV}
+        echo 'export REGISTRY_EMAIL=none' >> ${BASH_ENV}
+        echo 'export DOCKERTAG=${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}' >> ${BASH_ENV}
   docker_build_and_push: &docker_build_and_push
     run:
       name: Docker login, build, and push
       command: |
+        touch empty.config
         docker login quay.io -u="reactiveops+circleci" -p="${quay_token}"
-        docker build -f Dockerfile -t quay.io/reactiveops/fairwinds:$DOCKER_BASE_TAG .
-        docker push quay.io/reactiveops/fairwinds:$DOCKER_BASE_TAG
+        docker-pull -f empty.config
+        docker-build -f empty.config
+        docker-push -f empty.config
+
 jobs:
+  build:
+    docker:
+      - image: quay.io/reactiveops/ci-images:v8.0-stretch
+    steps:
+      - checkout
+      - setup_remote_docker
+      - *set_environment_variables
+      - *docker_build_and_push
+
   test:
     working_directory: /go/src/github.com/reactiveops/fairwinds/
     docker:
@@ -22,14 +47,20 @@ jobs:
       - run: go list ./... | grep -v vendor | xargs go vet
       - run: go test ./pkg/... -v -coverprofile cover.out
 
-  build:
+  test-deploy:
     docker:
-      - image: circleci/buildpack-deps:stretch
+      - image: quay.io/reactiveops/ci-images:v8.0-stretch
     steps:
       - checkout
-      - setup_remote_docker
-      - run: echo 'export DOCKER_BASE_TAG=dev-$CIRCLE_SHA1' >> $BASH_ENV
-      - *docker_build_and_push
+      - run:
+          name: Verify helm chart synced with all.yaml
+          command: |
+            diff \
+              <(helm template deploy/helm/fairwinds/ --name fairwinds --namespace fairwinds --set templateOnly=true) \
+              deploy/all.yaml || (echo "
+                Make sure to regenerate deploy/all.yaml based on the helm chart.
+                helm template deploy/helm/fairwinds/ --name fairwinds --namespace fairwinds --set templateOnly=true" &&
+                exit 1)
 
   release:
     docker:
@@ -37,16 +68,19 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - run: echo 'export DOCKER_BASE_TAG=$CIRCLE_TAG' >> $BASH_ENV
-      - *docker_build_and_push
-
+      - *set_environment_variables
+      - *docker_build_and_push #TODO don't rebuild for release
 
 workflows:
   version: 2
   build:
     jobs:
       - test
+      - test-deploy
       - build:
+          requires:
+            - test
+            - test-deploy
           context: org-global
           # Allow using testing tags for testing circle test + build steps
           filters:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The Fairwinds Dashboard provides an overview of your current deployments in a cl
 To deploy Fairwinds with kubectl:
 
 ```
+kubectl create namespace fairwinds
 kubectl apply -f https://raw.githubusercontent.com/reactiveops/fairwinds/master/deploy/all.yaml
 ```
 

--- a/deploy/all.yaml
+++ b/deploy/all.yaml
@@ -1,63 +1,11 @@
 ---
-kind: Service
-apiVersion: v1
-metadata:
-  name: fairwinds-dash
-spec:
-  selector:
-    app: fairwinds
-  ports:
-  - name: dashboard
-    protocol: TCP
-    port: 80
-    targetPort: 8080
----
+# Source: fairwinds/templates/namespace.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: fairwinds
-  labels:
-    app: fairwinds
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: fairwinds
-  namespace: fairwinds
-  labels:
-    app: fairwinds
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
-metadata:
-  name: fairwinds
-  labels:
-    app: fairwinds
-rules:
-  - apiGroups:
-    - ''
-    - 'apps'
-    - 'admissionregistration.k8s.io'
-    resources:
-      - '*'
-    verbs:
-      - '*'
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: fairwinds
-  labels:
-    app: fairwinds
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: fairwinds
-subjects:
-  - kind: ServiceAccount
-    name: fairwinds
-    namespace: fairwinds
----
+# Source: fairwinds/templates/secret.yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -65,7 +13,10 @@ metadata:
   namespace: fairwinds
   labels:
     app: fairwinds
+type: Opaque
+data:
 ---
+# Source: fairwinds/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -74,7 +25,7 @@ metadata:
   labels:
     app: fairwinds
 data:
-  config.yaml: |
+  config.yaml:  |
     resources:
       cpuRequestsMissing: error
       cpuLimitsMissing: error
@@ -99,8 +50,8 @@ data:
       capabilities:
         error:
           ifAnyAdded:
-            - CAP_SYS_ADMIN
-            - CAP_NET_ADMIN
+            - SYS_ADMIN
+            - NET_ADMIN
             - ALL
         warning:
           ifAnyAddedBeyond:
@@ -118,68 +69,197 @@ data:
             - SYS_CHROOT
             - KILL
             - AUDIT_WRITE
+  
 ---
-apiVersion: extensions/v1beta1
-kind: Deployment
+# Source: fairwinds/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: fairwinds
   namespace: fairwinds
   labels:
     app: fairwinds
+
+---
+# Source: fairwinds/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: fairwinds
+  labels:
+    app: fairwinds
+rules:
+  - apiGroups:
+    - ''
+    - 'apps'
+    - 'admissionregistration.k8s.io'
+    resources:
+      - '*'
+    verbs:
+      - '*'
+---
+# Source: fairwinds/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: fairwinds
+  labels:
+    app: fairwinds
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: fairwinds
+subjects:
+  - kind: ServiceAccount
+    name: fairwinds
+    namespace: fairwinds
+---
+# Source: fairwinds/templates/dashboard.service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: fairwinds-dashboard
+  namespace: fairwinds
+  labels:
+    app: fairwinds
+spec:
+  ports:
+  - name: dashboard
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: fairwinds
+    component: dashboard
+  type: ClusterIP
+---
+# Source: fairwinds/templates/dashboard.deployment.yaml
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    checksum/config: 'af539094a198a41b47151133fbf9c53309b0b621234185a651af15723f2c92ab'
+  name: fairwinds-dashboard
+  namespace: fairwinds
+  labels:
+    app: fairwinds
+    component: dashboard
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: fairwinds
+      component: dashboard
   template:
     metadata:
       labels:
         app: fairwinds
+        component: dashboard
     spec:
-      serviceAccountName: fairwinds
-      containers:
-      - name: webhook
-        image: quay.io/reactiveops/fairwinds
-        command: ["fairwinds", "--webhook"]
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 9876
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 100m
-            memory: 128Mi
-        volumeMounts:
-        - name: certs
-          mountPath: /tmp/cert/
-        - name: fairwinds
-          mountPath: /opt/app/config.yaml
-          subPath: config.yaml
-          readOnly: true
-      - name: dashboard
-        image: quay.io/reactiveops/fairwinds
-        command: ["fairwinds", "--dashboard"]
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 8080
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 100m
-            memory: 128Mi
-        volumeMounts:
-        - name: fairwinds
-          mountPath: /opt/app/config.yaml
-          subPath: config.yaml
-          readOnly: true
       volumes:
-      - name: fairwinds
+      - name: config
         configMap:
           name: fairwinds
-      - name: certs
+      containers:
+      - command:
+        - fairwinds
+        - --dashboard
+        image: 'quay.io/reactiveops/fairwinds:master'
+        imagePullPolicy: 'Always'
+        name: dashboard
+        ports:
+        - containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - name: config
+          mountPath: /opt/app/config.yaml
+          subPath: config.yaml
+          readOnly: true
+      serviceAccountName: fairwinds
+---
+# Source: fairwinds/templates/webhook.deployment.yaml
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    checksum/config: 'af539094a198a41b47151133fbf9c53309b0b621234185a651af15723f2c92ab'
+  name: fairwinds-webhook
+  namespace: fairwinds
+  labels:
+    app: fairwinds
+    component: webhook
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fairwinds
+      component: webhook
+  template:
+    metadata:
+      labels:
+        app: fairwinds
+        component: webhook
+    spec:
+      volumes:
+      - name: config
+        configMap:
+          name: fairwinds
+      - name: secret
         secret:
           secretName: fairwinds
+      containers:
+      - command:
+        - fairwinds
+        - --webhook
+        image: 'quay.io/reactiveops/fairwinds:master'
+        imagePullPolicy: 'Always'
+        name: webhook
+        ports:
+        - containerPort: 9876
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - ps -ef | grep fairwinds
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        readinessProbe:
+          tcpSocket:
+            port: 9876
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - name: config
+          mountPath: /opt/app/config.yaml
+          subPath: config.yaml
+          readOnly: true
+        - name: secret
+          mountPath: /tmp/cert/
+          readOnly: true
+      serviceAccountName:  fairwinds

--- a/deploy/helm/fairwinds/templates/_helpers.tpl
+++ b/deploy/helm/fairwinds/templates/_helpers.tpl
@@ -30,3 +30,29 @@ Create chart name and version as used by the chart label.
 {{- define "fairwinds.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Standard labels
+*/}}
+{{- define "fairwinds.labels" -}}
+{{- if .Values.templateOnly -}}
+app: {{ include "fairwinds.name" . }}
+{{- else -}}
+app.kubernetes.io/name: {{ include "fairwinds.name" . }}
+helm.sh/chart: {{ include "fairwinds.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Standard selector
+*/}}
+{{- define "fairwinds.selectors" -}}
+{{- if .Values.templateOnly -}}
+app: {{ include "fairwinds.name" . }}
+{{- else -}}
+app.kubernetes.io/name: {{ include "fairwinds.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/fairwinds/templates/clusterrole.yaml
+++ b/deploy/helm/fairwinds/templates/clusterrole.yaml
@@ -4,10 +4,7 @@ kind: ClusterRole
 metadata:
   name: {{ include "fairwinds.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "fairwinds.name" . }}
-    helm.sh/chart: {{ include "fairwinds.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "fairwinds.labels" . | nindent 4 }}
 rules:
   - apiGroups:
     - ''

--- a/deploy/helm/fairwinds/templates/clusterrolebinding.yaml
+++ b/deploy/helm/fairwinds/templates/clusterrolebinding.yaml
@@ -4,10 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "fairwinds.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "fairwinds.name" . }}
-    helm.sh/chart: {{ include "fairwinds.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "fairwinds.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy/helm/fairwinds/templates/configmap.yaml
+++ b/deploy/helm/fairwinds/templates/configmap.yaml
@@ -2,10 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "fairwinds.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ include "fairwinds.name" . }}
-    helm.sh/chart: {{ include "fairwinds.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "fairwinds.labels" . | nindent 4 }}
 data:
   config.yaml: {{- toYaml .Values.config | indent 2 -}}

--- a/deploy/helm/fairwinds/templates/dashboard.deployment.yaml
+++ b/deploy/helm/fairwinds/templates/dashboard.deployment.yaml
@@ -5,33 +5,26 @@ metadata:
   annotations:
     checksum/config: '{{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}'
   name: {{ include "fairwinds.fullname" . }}-dashboard
+  namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ include "fairwinds.name" . }}
-    helm.sh/chart: {{ include "fairwinds.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "fairwinds.labels" . | nindent 4 }}
     component: dashboard
 spec:
   replicas: {{.Values.dashboard.replicas}}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "fairwinds.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "fairwinds.selectors" . | nindent 6 }}
       component: dashboard
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "fairwinds.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- include "fairwinds.selectors" . | nindent 8 }}
         component: dashboard
     spec:
       volumes:
-      - configMap:
-          name: {{ include "fairwinds.name" . }}
-        name: {{ include "fairwinds.name" . }}
-      - name: certs
-        secret:
-          secretName: {{ include "fairwinds.name" . }}
+      - name: config
+        configMap:
+          name: {{ include "fairwinds.fullname" . }}
       containers:
       - command:
         - fairwinds
@@ -61,9 +54,9 @@ spec:
             cpu: 100m
             memory: 128Mi
         volumeMounts:
-        - mountPath: /opt/app/config.yaml
-          name: {{ include "fairwinds.name" . }}
-          readOnly: true
+        - name: config
+          mountPath: /opt/app/config.yaml
           subPath: config.yaml
+          readOnly: true
       serviceAccountName: {{ include "fairwinds.name" . }}
 {{- end -}}

--- a/deploy/helm/fairwinds/templates/dashboard.service.yaml
+++ b/deploy/helm/fairwinds/templates/dashboard.service.yaml
@@ -3,11 +3,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "fairwinds.fullname" . }}-dashboard
+  namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ include "fairwinds.name" . }}
-    helm.sh/chart: {{ include "fairwinds.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "fairwinds.labels" . | nindent 4 }}
 spec:
   ports:
   - name: dashboard
@@ -15,7 +13,7 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    app.kubernetes.io/name: {{ .Release.Name }}
+    {{- include "fairwinds.selectors" . | nindent 4 }}
     component: dashboard
   type: {{ .Values.dashboard.service.type }}
 {{- end -}}

--- a/deploy/helm/fairwinds/templates/namespace.yaml
+++ b/deploy/helm/fairwinds/templates/namespace.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.templateOnly -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace }}
+{{- end -}}

--- a/deploy/helm/fairwinds/templates/secret.yaml
+++ b/deploy/helm/fairwinds/templates/secret.yaml
@@ -1,11 +1,11 @@
+{{- if .Values.webhook.enable -}}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "fairwinds.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ include "fairwinds.name" . }}
-    helm.sh/chart: {{ include "fairwinds.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-type: opaque
+    {{- include "fairwinds.labels" . | nindent 4 }}
+type: Opaque
 data:
+{{- end -}}

--- a/deploy/helm/fairwinds/templates/serviceaccount.yaml
+++ b/deploy/helm/fairwinds/templates/serviceaccount.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "fairwinds.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ include "fairwinds.name" . }}
-    helm.sh/chart: {{ include "fairwinds.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "fairwinds.labels" . | nindent 4 }}

--- a/deploy/helm/fairwinds/templates/webhook.deployment.yaml
+++ b/deploy/helm/fairwinds/templates/webhook.deployment.yaml
@@ -3,35 +3,31 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   annotations:
-    checksum/config: '{{ include (print $.Template.BasePath "/fairwinds.configmap.yaml") . | sha256sum }}'
+    checksum/config: '{{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}'
   name: {{ include "fairwinds.fullname" . }}-webhook
+  namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ include "fairwinds.name" . }}
-    helm.sh/chart: {{ include "fairwinds.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "fairwinds.labels" . | nindent 4 }}
     component: webhook
 spec:
   replicas: {{ .Values.webhook.replicas }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "fairwinds.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "fairwinds.selectors" . | nindent 6 }}
       component: webhook
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "fairwinds.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- include "fairwinds.selectors" . | nindent 8 }}
         component: webhook
     spec:
       volumes:
-      - configMap:
-          name:  {{ include "fairwinds.name" . }}
-        name:  {{ include "fairwinds.name" . }}
-      - name: certs
+      - name: config
+        configMap:
+          name: {{ include "fairwinds.fullname" . }}
+      - name: secret
         secret:
-          secretName:  {{ include "fairwinds.name" . }}
+          secretName: {{ include "fairwinds.fullname" . }}
       containers:
       - command:
         - fairwinds
@@ -51,7 +47,7 @@ spec:
           periodSeconds: 5
         readinessProbe:
           tcpSocket:
-            port: 8080
+            port: 9876
           initialDelaySeconds: 15
           periodSeconds: 20
         resources:
@@ -62,11 +58,12 @@ spec:
             cpu: 100m
             memory: 128Mi
         volumeMounts:
-        - mountPath: /tmp/cert/
-          name: certs
-        - mountPath: /opt/app/config.yml
-          name:  {{ include "fairwinds.name" . }}
+        - name: config
+          mountPath: /opt/app/config.yaml
+          subPath: config.yaml
           readOnly: true
-          subPath: config.yml
+        - name: secret
+          mountPath: /tmp/cert/
+          readOnly: true
       serviceAccountName:  {{ include "fairwinds.name" . }}
 {{- end -}}

--- a/deploy/helm/fairwinds/values.yaml
+++ b/deploy/helm/fairwinds/values.yaml
@@ -51,16 +51,18 @@ dashboard:
     type: ClusterIP
   image:
     repository: quay.io/reactiveops/fairwinds
-    tag: dev-7263ff7e59b3809bf8ea5e7845261a9da14752c7
+    tag: master
     pullPolicy: Always
 
 webhook:
-  enable: false
+  enable: true
   replicas: 1
   image:
     repository: quay.io/reactiveops/fairwinds
-    tag: dev-7263ff7e59b3809bf8ea5e7845261a9da14752c7
+    tag: master
     pullPolicy: Always
 
 rbac:
   create: true
+
+templateOnly: false


### PR DESCRIPTION
Fixes #53 
- [x] Sync everything in `deploy/all.yaml` and `deploy/helm/templates`
- [x] Handle certs/secret for webhook
- [x] Ensure things stay in sync

There were a few inconsistencies between the chart and the all.yaml that this irons out. It fixes up things like volume names, port numbers, and default configs. The `all.yaml` is now just the output of `helm template` and Circle now asserts that as well.

When generating the `all.yaml` we use a new `basicLabels` option that removes all the standard helm labels in favor of just a simple labeling scheme.

This also includes rok8s-scripts for docker build/push to benefit from better caching and changes the chart (and `all.yaml`) to use the `master` tag by default.

Future things to handle:
- don't rebuild the image when we release
- figure out a better way to keep `all.yaml` pointing to the latest image that it works with (goes along with discussion about where to ultimately host the chart)