### PR TITLE
Add support for LimitRange

### DIFF
--- a/deploy/dashboard.yaml
+++ b/deploy/dashboard.yaml
@@ -90,6 +90,7 @@ rules:
       - 'nodes'
       - 'namespaces'
       - 'pods'
+      - 'limitranges'
     verbs:
       - 'get'
       - 'list'

--- a/deploy/webhook.yaml
+++ b/deploy/webhook.yaml
@@ -88,11 +88,13 @@ metadata:
     app: polaris
 rules:
   - apiGroups:
+      - ''
       - 'apps'
       - 'extensions'
     resources:
       - 'deployments'
       - 'statefulsets'
+      - 'limitranges'
     verbs:
       - 'get'
       - 'list'

--- a/pkg/kube/resources_test.go
+++ b/pkg/kube/resources_test.go
@@ -31,6 +31,9 @@ func TestGetResourcesFromPath(t *testing.T) {
 	assert.Equal(t, 2, len(resources.Pods), "Should have two pods")
 	assert.Equal(t, "", resources.Pods[0].ObjectMeta.Namespace, "Should have one pod in default namespace")
 	assert.Equal(t, "two", resources.Pods[1].ObjectMeta.Namespace, "Should have one pod in namespace 'two'")
+
+	assert.Equal(t, 1, len(resources.LimitRanges), "Should have one LimitRange")
+	assert.Equal(t, "limit", resources.LimitRanges[0].ObjectMeta.Namespace)
 }
 
 func TestGetMultipleResourceFromSingleFile(t *testing.T) {
@@ -55,7 +58,7 @@ func TestGetMultipleResourceFromSingleFile(t *testing.T) {
 
 func TestGetResourceFromAPI(t *testing.T) {
 	k8s := test.SetupTestAPI()
-	k8s = test.SetupAddControllers(k8s, "test")
+	test.SetupAddControllers(k8s, "test")
 	resources, err := CreateResourceProviderFromAPI(k8s, "test")
 	assert.Equal(t, nil, err, "Error should be nil")
 

--- a/pkg/kube/test_files/test_1/limit_range.yaml
+++ b/pkg/kube/test_files/test_1/limit_range.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limit
+  namespace: limit
+spec:
+  limits:
+  - max:
+      cpu: "800m"
+      memory: "1Gi"
+    min:
+      cpu: "100m"
+      memory: "99Mi"
+    default:
+      cpu: "700m"
+      memory: "900Mi"
+    defaultRequest:
+      cpu: "110m"
+      memory: "111Mi"
+    type: Container
+

--- a/pkg/validator/controller_test.go
+++ b/pkg/validator/controller_test.go
@@ -1,0 +1,55 @@
+package validator
+
+import (
+	"testing"
+
+	conf "github.com/reactiveops/polaris/pkg/config"
+	"github.com/reactiveops/polaris/pkg/kube"
+	"github.com/reactiveops/polaris/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateController(t *testing.T) {
+	k8s := test.SetupTestAPI()
+	test.SetupAddControllers(k8s, "test")
+	resources, err := kube.CreateResourceProviderFromAPI(k8s, "test")
+	assert.Equal(t, err, nil, "error should be nil")
+
+	c := conf.Configuration{}
+
+	nsResults := &NamespacedResults{}
+	ValidateControllers(c, resources, nsResults)
+	assert.Equal(t, 1, len((*nsResults)["test"].DeploymentResults), "")
+	assert.Equal(t, 1, len((*nsResults)["test"].StatefulSetResults), "")
+}
+
+func TestLimitRanges(t *testing.T) {
+	k8s := test.SetupTestAPI()
+	test.SetupAddControllers(k8s, "test")
+	resources, err := kube.CreateResourceProviderFromAPI(k8s, "test")
+	assert.Equal(t, err, nil, "error should be nil")
+
+	c := conf.Configuration{
+		Resources: conf.Resources{
+			CPURequestsMissing:    conf.SeverityError,
+			CPULimitsMissing:      conf.SeverityError,
+			MemoryRequestsMissing: conf.SeverityError,
+			MemoryLimitsMissing:   conf.SeverityError,
+		},
+	}
+
+	nsResults := &NamespacedResults{}
+	ValidateControllers(c, resources, nsResults)
+	assert.Equal(t, 1, len((*nsResults)["test"].DeploymentResults), "")
+	podRes := (*nsResults)["test"].DeploymentResults[0].PodResult
+	assert.Equal(t, uint(0), podRes.Summary.Totals.Successes, "")
+	assert.Equal(t, uint(4), podRes.Summary.Totals.Errors, "")
+
+	test.SetupAddLimitRanges(k8s, "test")
+	resources, err = kube.CreateResourceProviderFromAPI(k8s, "test")
+	nsResults = &NamespacedResults{}
+	ValidateControllers(c, resources, nsResults)
+	podRes = (*nsResults)["test"].DeploymentResults[0].PodResult
+	assert.Equal(t, uint(4), podRes.Summary.Totals.Successes, "")
+	assert.Equal(t, uint(0), podRes.Summary.Totals.Errors, "")
+}

--- a/pkg/validator/fullaudit_test.go
+++ b/pkg/validator/fullaudit_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestGetTemplateData(t *testing.T) {
 	k8s := test.SetupTestAPI()
-	k8s = test.SetupAddControllers(k8s, "test")
+	test.SetupAddControllers(k8s, "test")
 	resources, err := kube.CreateResourceProviderFromAPI(k8s, "test")
 	assert.Equal(t, err, nil, "error should be nil")
 

--- a/pkg/validator/pod_test.go
+++ b/pkg/validator/pod_test.go
@@ -35,7 +35,7 @@ func TestValidatePod(t *testing.T) {
 	}
 
 	k8s := test.SetupTestAPI()
-	k8s = test.SetupAddControllers(k8s, "test")
+	test.SetupAddControllers(k8s, "test")
 	pod := test.MockPod()
 
 	expectedSum := ResultSummary{

--- a/test/fixtures.go
+++ b/test/fixtures.go
@@ -1,10 +1,9 @@
 package test
 
 import (
-	"fmt"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -49,22 +48,49 @@ func mockStatefulSet() appsv1.StatefulSet {
 	return s
 }
 
+func mockLimitRange() corev1.LimitRange {
+	lr := corev1.LimitRange{
+		Spec: corev1.LimitRangeSpec{
+			Limits: []corev1.LimitRangeItem{
+				corev1.LimitRangeItem{
+					Type:           corev1.LimitTypeContainer,
+					Default:        make(map[corev1.ResourceName]resource.Quantity),
+					DefaultRequest: make(map[corev1.ResourceName]resource.Quantity),
+				},
+			},
+		},
+	}
+	lr.Spec.Limits[0].Default[corev1.ResourceCPU] = resource.MustParse("500m")
+	lr.Spec.Limits[0].Default[corev1.ResourceMemory] = resource.MustParse("5Gi")
+	lr.Spec.Limits[0].DefaultRequest[corev1.ResourceCPU] = resource.MustParse("500m")
+	lr.Spec.Limits[0].DefaultRequest[corev1.ResourceMemory] = resource.MustParse("5Gi")
+	return lr
+}
+
 // SetupTestAPI creates a test kube API struct.
 func SetupTestAPI() kubernetes.Interface {
 	return fake.NewSimpleClientset()
 }
 
 // SetupAddControllers creates mock controllers and adds them to the test clientset.
-func SetupAddControllers(k kubernetes.Interface, namespace string) kubernetes.Interface {
+func SetupAddControllers(k kubernetes.Interface, namespace string) {
 	d1 := mockDeploy()
 	_, err := k.AppsV1().Deployments(namespace).Create(&d1)
 	if err != nil {
-		fmt.Println(err)
+		panic(err)
 	}
 	s1 := mockStatefulSet()
 	_, err = k.AppsV1().StatefulSets(namespace).Create(&s1)
 	if err != nil {
-		fmt.Println(err)
+		panic(err)
 	}
-	return k
+}
+
+// SetupAddLimitRanges creates mock limit ranges and adds them to the test clientset.
+func SetupAddLimitRanges(k kubernetes.Interface, namespace string) {
+	lr := mockLimitRange()
+	_, err := k.CoreV1().LimitRanges(namespace).Create(&lr)
+	if err != nil {
+		panic(err)
+	}
 }


### PR DESCRIPTION
This supports setting `default` and `defaultRequests` in a `LimitRange` config with `type == Container`.

A couple questions:
* should setting `min` and `max` in `LimitRange` count as well? Guessing that only affects `limits` and not `requests`?
* should we handle `type == Pod`? IIUC, no, because we're checking container-level limits here, and that sets limits for the pod as a whole.