### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,54 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+---
+name: Bug report
+about: Let us know about an unexpected error, a crash, or an incorrect behavior.
+
+---
+
+### Polaris Version
+<!---
+Run `polaris --version` to show the version, and paste the result between the ``` marks below.
+
+If you are not running the latest version of Polaris, please try upgrading because your issue may have already been fixed.
+-->
+
+```
+...
+```
+
+### Expected Behavior
+<!--
+What should have happened?
+-->
+
+### Actual Behavior
+<!--
+What actually happened?
+-->
+
+### Steps to Reproduce
+<!--
+Please list the full steps required to reproduce the issue, for example:
+1. `polaris --audit --output-format score`
+-->
+
+### Additional Context
+<!--
+Are there anything atypical about your situation that we should know? 
+-->
+
+### References
+<!--
+Are there any other GitHub issues (open or closed) or Pull Requests that should be linked here? For example:
+
+- #6017
+
+-->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,10 +12,14 @@ name: Bug report
 about: Let us know about an unexpected error, a crash, or an incorrect behavior.
 
 ---
+### Installation Process
+<!--- 
+Did you install polaris on your local machine, or in a kubernetes cluster? Did you use kubectl, helm, brew, a GitHub release, or the source code? Let us know below. 
+--> 
 
 ### Polaris Version
 <!---
-Run `polaris --version` to show the version, and paste the result between the ``` marks below.
+If you are using polaris locally, run `polaris --version` to show the version, and paste the result between the ``` marks below.
 
 If you are not running the latest version of Polaris, please try upgrading because your issue may have already been fixed.
 -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -1,0 +1,10 @@
+---
+name: Other
+about: For misc. tasks like research or continued conversation
+title: ''
+labels: ''
+assignees: kimschles
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -3,7 +3,7 @@ name: Other
 about: For misc. tasks like research or continued conversation
 title: ''
 labels: ''
-assignees: kimschles
+assignees: ''
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,11 +40,8 @@ go test ./pkg/... -v -coverprofile cover.out
 
 ## Creating a New Issue
 
-If you've encountered an issue that is not already reported, please create an issue that contains the following:
+If you've encountered an issue that is not already reported, please create a [new issue](https://github.com/FairwindsOps/polaris/issues), choose `Bug Report`, `Feature Request` or `Misc.` and follow the instructions in the template. 
 
-- Clear description of the issue
-- Steps to reproduce it
-- Appropriate labels
 
 ## Creating a Pull Request
 


### PR DESCRIPTION
I've added issues templates for bug reports, feature requests and other as a response to feedback left on this PR: https://github.com/FairwindsOps/polaris/pull/168. 

The goal of these templates is to better organize our issues, as well as encourage folks who are filing a bug report to check their version of polaris and update when necessary. 