### PR TITLE
Fix chart repository name in docs

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -95,7 +95,7 @@ kubectl port-forward --namespace polaris svc/polaris-dashboard 8080:80
 ```
 ### Helm
 ```bash
-helm repo add fairwinds-stable https://charts.fairwindsops.com/stable
+helm repo add fairwinds-stable https://charts.fairwinds.com/stable
 helm upgrade --install polaris fairwinds-stable/polaris --namespace polaris
 kubectl port-forward --namespace polaris svc/polaris-dashboard 8080:80
 ```


### PR DESCRIPTION
charts.fairwindsops.com doesn't resolve, fixed according to https://github.com/FairwindsOps/charts