### PR TITLE
Don't assume all objects have pods.

### DIFF
--- a/pkg/kube/resources.go
+++ b/pkg/kube/resources.go
@@ -228,7 +228,10 @@ func GetPodSpec(yaml map[string]interface{}) interface{} {
 			return GetPodSpec(childYaml.(map[string]interface{}))
 		}
 	}
-	return yaml
+	if _, ok := yaml["containers"]; ok {
+		return yaml
+	}
+	return nil
 }
 
 func addResourceFromString(contents string, resources *ResourceProvider) error {
@@ -268,7 +271,11 @@ func addResourceFromString(contents string, resources *ResourceProvider) error {
 		finalDoc["metadata"] = yamlNode["metadata"]
 		finalDoc["apiVersion"] = "v1"
 		finalDoc["kind"] = "Pod"
-		finalDoc["spec"] = GetPodSpec(yamlNode)
+		podSpec := GetPodSpec(yamlNode)
+		if podSpec == nil {
+			return nil
+		}
+		finalDoc["spec"] = podSpec
 		marshaledYaml, err := yaml.Marshal(finalDoc)
 		if err != nil {
 			logrus.Errorf("Could not marshal yaml: %v", err)

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -17,6 +17,7 @@ package webhook
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -101,6 +102,9 @@ func (v *Validator) handleInternal(ctx context.Context, req types.Request) (*val
 			return nil, err
 		}
 		podMap := kube.GetPodSpec(decoded)
+		if podMap == nil {
+			return nil, errors.New("Object does not contain pods")
+		}
 		encoded, err := json.Marshal(podMap)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
The string based audits are picking up services and other objects as controllers. See issue #328