### PR TITLE
Adds option to exempt an entire controller from checks via config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ main
 
 *-packr.go
 dist
+.vscode

--- a/pkg/config/exemptions.go
+++ b/pkg/config/exemptions.go
@@ -12,11 +12,19 @@ func (conf Configuration) IsActionable(ruleID, controllerName string) bool {
 	if conf.DisallowExemptions {
 		return true
 	}
+
 	for _, example := range conf.Exemptions {
 		for _, rule := range example.Rules {
 			if rule != ruleID {
 				continue
 			}
+			for _, controller := range example.ControllerNames {
+				if strings.HasPrefix(controllerName, controller) {
+					return false
+				}
+			}
+		}
+		if len(example.Rules) == 0 {
 			for _, controller := range example.ControllerNames {
 				if strings.HasPrefix(controllerName, controller) {
 					return false

--- a/pkg/config/exemptions_test.go
+++ b/pkg/config/exemptions_test.go
@@ -1,0 +1,62 @@
+// Copyright 2019 FairwindsOps Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var confExemptRuleTest = `
+checks:
+  ANY: warning
+  OTHER: warning
+exemptions:
+  - controllerNames:
+    - test
+    rules:
+    - ANY
+`
+
+var confExemptTest = `
+checks:
+  ANY: warning
+exemptions:
+  - controllerNames:
+      - test
+`
+
+func TestInclusiveExemption(t *testing.T) {
+	parsedConf, _ := Parse([]byte(confExemptTest))
+	applicable := parsedConf.IsActionable("ANY", "test")
+	applicableOtherController := parsedConf.IsActionable("ANY", "other")
+
+	assert.False(t, applicable, "Expected all checks to be exempted when their controller is specified.")
+	assert.True(t, applicableOtherController, "Expected checks to only be exempted when their controller is specified.")
+}
+
+func TestIndividualRuleException(t *testing.T) {
+	parsedConf, _ := Parse([]byte(confExemptRuleTest))
+	applicable := parsedConf.IsActionable("ANY", "test")
+	applicableOtherRule := parsedConf.IsActionable("OTHER", "test")
+	applicableOtherRuleOtherController := parsedConf.IsActionable("OTHER", "other")
+	applicableRuleOtherController := parsedConf.IsActionable("ANY", "other")
+
+	assert.False(t, applicable, "Expected all checks to be exempted when their controller and rule are specified.")
+	assert.True(t, applicableOtherRule, "Expected checks to only be exempted when their controller and rule are specified.")
+	assert.True(t, applicableOtherRuleOtherController, "Expected checks to only be exempted when their controller and rule are specified.")
+	assert.True(t, applicableRuleOtherController, "Expected checks to only be exempted when their controller and rule are specified.")
+}


### PR DESCRIPTION
This adds the ability to exempt a controller from all checks similar to
the annotation for "exempt" which exempts all checks.

I added the tests to go with this as well as for the IsActionable
function.

Validation Commands:
```bash
[3:36:45] ~/go/src/github.com/fairwindsops/polaris [add_controller_wide_exemption] λ go list ./... | grep -v vendor | xargs golint -set_exit_status
[3:39:09] ~/go/src/github.com/fairwindsops/polaris [add_controller_wide_exemption] λ echo $?
0
[3:39:19] ~/go/src/github.com/fairwindsops/polaris [add_controller_wide_exemption] λ go list ./... | grep -v vendor | xargs go vet
[3:39:31] ~/go/src/github.com/fairwindsops/polaris [add_controller_wide_exemption] λ echo $?
0
[3:39:40] ~/go/src/github.com/fairwindsops/polaris [add_controller_wide_exemption] λ go test ./pkg/... -v -coverprofile cover.out
=== RUN   TestParseError
--- PASS: TestParseError (0.00s)
=== RUN   TestParseYaml
--- PASS: TestParseYaml (0.00s)
=== RUN   TestParseJson
--- PASS: TestParseJson (0.00s)
=== RUN   TestConfigFromURL
--- PASS: TestConfigFromURL (1.00s)
=== RUN   TestConfigNoServerError
--- PASS: TestConfigNoServerError (0.00s)
=== RUN   TestConfigWithCustomChecks
--- PASS: TestConfigWithCustomChecks (0.00s)
=== RUN   TestInclusiveExemption
--- PASS: TestInclusiveExemption (0.00s)
=== RUN   TestIndividualRuleException
--- PASS: TestIndividualRuleException (0.00s)
PASS
coverage: 42.4% of statements
ok      github.com/fairwindsops/polaris/pkg/config      2.935s  coverage: 42.4% of statements
?       github.com/fairwindsops/polaris/pkg/dashboard   [no test files]
=== RUN   TestGetResourcesFromPath
--- PASS: TestGetResourcesFromPath (0.01s)
=== RUN   TestGetMultipleResourceFromSingleFile
--- PASS: TestGetMultipleResourceFromSingleFile (0.00s)
=== RUN   TestGetMultipleResourceFromBadFile
time="2020-06-15T15:39:54-05:00" level=error msg="Invalid YAML: --\n# Source: polaris/templates/dashboard.deployment.yaml\napiVersion: extensions/v1beta1\nkind: Deployment\n::::\n"
time="2020-06-15T15:39:54-05:00" level=error msg="Error parsing YAML: (error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type kube.k8sResource)"
--- PASS: TestGetMultipleResourceFromBadFile (0.00s)
=== RUN   TestGetResourceFromAPI
--- PASS: TestGetResourceFromAPI (0.00s)
PASS
coverage: 60.5% of statements
ok      github.com/fairwindsops/polaris/pkg/kube        0.358s  coverage: 60.5% of statements
=== RUN   TestValidateResourcesEmptyConfig
--- PASS: TestValidateResourcesEmptyConfig (0.00s)
=== RUN   TestValidateResourcesEmptyContainer
--- PASS: TestValidateResourcesEmptyContainer (0.00s)
=== RUN   TestValidateHealthChecks
=== RUN   TestValidateHealthChecks/probes_not_configured
=== RUN   TestValidateHealthChecks/probes_not_required
=== RUN   TestValidateHealthChecks/probes_required_&_configured
=== RUN   TestValidateHealthChecks/probes_required,_not_configured,_but_init
=== RUN   TestValidateHealthChecks/probes_required_&_not_configured
=== RUN   TestValidateHealthChecks/probes_configured,_but_not_required
--- PASS: TestValidateHealthChecks (0.00s)
    --- PASS: TestValidateHealthChecks/probes_not_configured (0.00s)
    --- PASS: TestValidateHealthChecks/probes_not_required (0.00s)
    --- PASS: TestValidateHealthChecks/probes_required_&_configured (0.00s)
    --- PASS: TestValidateHealthChecks/probes_required,_not_configured,_but_init (0.00s)
    --- PASS: TestValidateHealthChecks/probes_required_&_not_configured (0.00s)
    --- PASS: TestValidateHealthChecks/probes_configured,_but_not_required (0.00s)
=== RUN   TestValidateImage
=== RUN   TestValidateImage/emptyConf_+_emptyCV
=== RUN   TestValidateImage/standardConf_+_emptyCV
=== RUN   TestValidateImage/standardConf_+_badCV
=== RUN   TestValidateImage/standardConf_+_lessBadCV
=== RUN   TestValidateImage/strongConf_+_badCV
=== RUN   TestValidateImage/strongConf_+_goodCV
--- PASS: TestValidateImage (0.00s)
    --- PASS: TestValidateImage/emptyConf_+_emptyCV (0.00s)
    --- PASS: TestValidateImage/standardConf_+_emptyCV (0.00s)
    --- PASS: TestValidateImage/standardConf_+_badCV (0.00s)
    --- PASS: TestValidateImage/standardConf_+_lessBadCV (0.00s)
    --- PASS: TestValidateImage/strongConf_+_badCV (0.00s)
    --- PASS: TestValidateImage/strongConf_+_goodCV (0.00s)
=== RUN   TestValidateNetworking
=== RUN   TestValidateNetworking/empty_ports_+_empty_validation_config
=== RUN   TestValidateNetworking/empty_ports_+_standard_validation_config
=== RUN   TestValidateNetworking/empty_ports_+_strong_validation_config
=== RUN   TestValidateNetworking/host_ports_+_empty_validation_config
=== RUN   TestValidateNetworking/host_ports_+_standard_validation_config
=== RUN   TestValidateNetworking/no_host_ports_+_standard_validation_config
=== RUN   TestValidateNetworking/host_ports_+_strong_validation_config
--- PASS: TestValidateNetworking (0.00s)
    --- PASS: TestValidateNetworking/empty_ports_+_empty_validation_config (0.00s)
    --- PASS: TestValidateNetworking/empty_ports_+_standard_validation_config (0.00s)
    --- PASS: TestValidateNetworking/empty_ports_+_strong_validation_config (0.00s)
    --- PASS: TestValidateNetworking/host_ports_+_empty_validation_config (0.00s)
    --- PASS: TestValidateNetworking/host_ports_+_standard_validation_config (0.00s)
    --- PASS: TestValidateNetworking/no_host_ports_+_standard_validation_config (0.00s)
    --- PASS: TestValidateNetworking/host_ports_+_strong_validation_config (0.00s)
=== RUN   TestValidateSecurity
=== RUN   TestValidateSecurity/empty_security_context_+_empty_validation_config
=== RUN   TestValidateSecurity/empty_security_context_+_standard_validation_config
=== RUN   TestValidateSecurity/bad_security_context_+_standard_validation_config
=== RUN   TestValidateSecurity/bad_security_context_+_standard_validation_config_with_good_settings_in_podspec
=== RUN   TestValidateSecurity/bad_security_context_+_standard_validation_config_from_default_set_in_podspec
=== RUN   TestValidateSecurity/good_security_context_+_standard_validation_config
=== RUN   TestValidateSecurity/good_security_context_+_strong_validation_config
=== RUN   TestValidateSecurity/strong_security_context_+_strong_validation_config
=== RUN   TestValidateSecurity/strong_security_context_+_strong_validation_config_via_podspec_default
=== RUN   TestValidateSecurity/strong_security_context_+_strong_validation_config_with_bad_setting_in_podspec_default
--- PASS: TestValidateSecurity (0.00s)
    --- PASS: TestValidateSecurity/empty_security_context_+_empty_validation_config (0.00s)
    --- PASS: TestValidateSecurity/empty_security_context_+_standard_validation_config (0.00s)
    --- PASS: TestValidateSecurity/bad_security_context_+_standard_validation_config (0.00s)
    --- PASS: TestValidateSecurity/bad_security_context_+_standard_validation_config_with_good_settings_in_podspec (0.00s)
    --- PASS: TestValidateSecurity/bad_security_context_+_standard_validation_config_from_default_set_in_podspec (0.00s)
    --- PASS: TestValidateSecurity/good_security_context_+_standard_validation_config (0.00s)
    --- PASS: TestValidateSecurity/good_security_context_+_strong_validation_config (0.00s)
    --- PASS: TestValidateSecurity/strong_security_context_+_strong_validation_config (0.00s)
    --- PASS: TestValidateSecurity/strong_security_context_+_strong_validation_config_via_podspec_default (0.00s)
    --- PASS: TestValidateSecurity/strong_security_context_+_strong_validation_config_with_bad_setting_in_podspec_default (0.00s)
=== RUN   TestValidateRunAsRoot
=== RUN   TestValidateRunAsRoot/pod=false,container=nil
=== RUN   TestValidateRunAsRoot/pod=false,container=true
=== RUN   TestValidateRunAsRoot/pod=nil,container=runAsUser
=== RUN   TestValidateRunAsRoot/pod=runAsUser,container=nil
=== RUN   TestValidateRunAsRoot/pod=runAsUser,container=runAsUser0
=== RUN   TestValidateRunAsRoot/pod=runAsUser,container=false
--- PASS: TestValidateRunAsRoot (0.00s)
    --- PASS: TestValidateRunAsRoot/pod=false,container=nil (0.00s)
    --- PASS: TestValidateRunAsRoot/pod=false,container=true (0.00s)
    --- PASS: TestValidateRunAsRoot/pod=nil,container=runAsUser (0.00s)
    --- PASS: TestValidateRunAsRoot/pod=runAsUser,container=nil (0.00s)
    --- PASS: TestValidateRunAsRoot/pod=runAsUser,container=runAsUser0 (0.00s)
    --- PASS: TestValidateRunAsRoot/pod=runAsUser,container=false (0.00s)
=== RUN   TestValidateResourcesExemption
--- PASS: TestValidateResourcesExemption (0.00s)
=== RUN   TestValidateResourcesEmptyContainerCPURequestsExempt
--- PASS: TestValidateResourcesEmptyContainerCPURequestsExempt (0.00s)
=== RUN   TestValidateController
--- PASS: TestValidateController (0.00s)
=== RUN   TestControllerLevelChecks
--- PASS: TestControllerLevelChecks (0.00s)
=== RUN   TestSkipHealthChecks
--- PASS: TestSkipHealthChecks (0.00s)
=== RUN   TestControllerExemptions
--- PASS: TestControllerExemptions (0.00s)
=== RUN   TestGetTemplateData
--- PASS: TestGetTemplateData (0.00s)
=== RUN   TestValidatePod
--- PASS: TestValidatePod (0.00s)
=== RUN   TestInvalidIPCPod
--- PASS: TestInvalidIPCPod (0.00s)
=== RUN   TestInvalidNeworkPod
--- PASS: TestInvalidNeworkPod (0.00s)
=== RUN   TestInvalidPIDPod
--- PASS: TestInvalidPIDPod (0.00s)
=== RUN   TestExemption
--- PASS: TestExemption (0.00s)
=== RUN   TestValidateResourcesPartiallyValid
--- PASS: TestValidateResourcesPartiallyValid (0.00s)
=== RUN   TestValidateResourcesInit
--- PASS: TestValidateResourcesInit (0.00s)
=== RUN   TestValidateResourcesFullyValid
--- PASS: TestValidateResourcesFullyValid (0.00s)
=== RUN   TestValidateCustomCheckExemptions
--- PASS: TestValidateCustomCheckExemptions (0.00s)
PASS
coverage: 64.1% of statements
ok      github.com/fairwindsops/polaris/pkg/validator   4.464s  coverage: 64.1% of statements
?       github.com/fairwindsops/polaris/pkg/webhook     [no test files]
```