### PR TITLE
Support read yaml contents of workload from stdin

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -149,6 +149,7 @@ Both the dashboard and audits can run against a local directory or YAML file
 rather than a cluster:
 ```bash
 polaris audit --audit-path ./deploy/
+cat pod.yaml | polaris audit --audit-path -
 ```
 
 #### Running with CI/CD


### PR DESCRIPTION
Closes #250

Usage:

```
cat pod.yaml | polaris audit --audit-path -
```