### PR TITLE
Fix error on Controller checks on orphaned pods

### DIFF
--- a/pkg/validator/schema.go
+++ b/pkg/validator/schema.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/fairwindsops/polaris/pkg/config"
 	"github.com/fairwindsops/polaris/pkg/kube"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -156,7 +157,8 @@ func applyControllerSchemaChecks(conf *config.Configuration, controller kube.Gen
 		}
 		passes, err := check.CheckController(controller.OriginalObjectJSON)
 		if err != nil {
-			return nil, err
+			logrus.Warningf("Error checking %s for %s/%s: %s (pod is possibly orphaned)", checkID, controller.ObjectMeta.GetNamespace(), controller.ObjectMeta.GetName(), err)
+			continue
 		}
 		results[check.ID] = makeResult(conf, check, passes)
 	}


### PR DESCRIPTION
Related issue: https://github.com/FairwindsOps/polaris/issues/327

Polaris errored when it wanted to run a Contoller check on a Pod which is
termination state and the related Controller is gone already. The
Dashboard showed `Error running audit`, the logs:
```
WARN[0014] An error occured validating controller:error parsing JSON bytes: unexpected end of JSON input
ERRO[0014] Error getting audit data: error parsing JSON bytes: unexpected end of JSON input
```

As this should happen only when a Deployment/StatefulSet/DaemonSet was
deleted, I consider it safe to ingore such problem on orphaned pods.

With this patch, Polaris will log a warning and continue instead.