### PR TITLE
Install Doc Updates

### DIFF
--- a/docs-md/admission-controller.md
+++ b/docs-md/admission-controller.md
@@ -24,7 +24,7 @@ kubectl apply -f https://github.com/fairwindsops/polaris/releases/latest/downloa
 
 ### Helm
 ```bash
-helm repo add fairwinds-stable https://charts.fairwindsops.com/stable
+helm repo add fairwinds-stable https://charts.fairwinds.com/stable
 helm upgrade --install polaris fairwinds-stable/polaris --namespace polaris \
   --set webhook.enable=true --set dashboard.enable=false
 ```

--- a/docs-md/admission-controller.md
+++ b/docs-md/admission-controller.md
@@ -13,9 +13,9 @@ A valid TLS certificate is required for the Polaris Validating Webhook. If you h
 
 If you don't use cert-manager, you'll need to:
 
-Supply a CA Bundle with the webhook.caBundle
-Create a TLS secret in your cluster with a valid certificate that uses that CA
-Pass the name of that secret with the webhook.secretName parameter.
+* Supply a CA Bundle with the webhook.caBundle
+* Create a TLS secret in your cluster with a valid certificate that uses that CA
+* Pass the name of that secret with the webhook.secretName parameter.
 
 ### kubectl
 ```bash

--- a/docs-md/admission-controller.md
+++ b/docs-md/admission-controller.md
@@ -9,6 +9,14 @@ configuration through dashboard visibility, but to actually enforce it with this
 Note that Polaris will not alter your workloads, only block workloads that don't conform to the configured policies.
 
 ## Installation
+A valid TLS certificate is required for the Polaris Validating Webhook. If you have cert-manager installed in your cluster then the helm install below will work.
+
+If you don't use cert-manager, you'll need to:
+
+Supply a CA Bundle with the webhook.caBundle
+Create a TLS secret in your cluster with a valid certificate that uses that CA
+Pass the name of that secret with the webhook.secretName parameter.
+
 ### kubectl
 ```bash
 kubectl apply -f https://github.com/fairwindsops/polaris/releases/latest/download/webhook.yaml
@@ -16,8 +24,8 @@ kubectl apply -f https://github.com/fairwindsops/polaris/releases/latest/downloa
 
 ### Helm
 ```bash
-helm repo add fairwindsops-stable https://charts.fairwindsops.com/stable
-helm upgrade --install polaris fairwindsops-stable/polaris --namespace polaris \
+helm repo add fairwinds-stable https://charts.fairwindsops.com/stable
+helm upgrade --install polaris fairwinds-stable/polaris --namespace polaris \
   --set webhook.enable=true --set dashboard.enable=false
 ```
 

--- a/docs-md/admission-controller.md
+++ b/docs-md/admission-controller.md
@@ -13,7 +13,7 @@ A valid TLS certificate is required for the Polaris Validating Webhook. If you h
 
 If you don't use cert-manager, you'll need to:
 
-* Supply a CA Bundle with the webhook.caBundle
+* Supply a CA Bundle with the `webhook.caBundle`
 * Create a TLS secret in your cluster with a valid certificate that uses that CA
 * Pass the name of that secret with the webhook.secretName parameter.
 
@@ -42,4 +42,3 @@ output unless we are rejecting a workload altogether.
 This means that any checks with a severity of `warning` will still pass webhook validation,
 and the only evidence of that warning will either be in the Polaris dashboard or the
 Polaris webhook logs. This will change in a future version of Kubernetes.
-

--- a/docs-md/admission-controller.md
+++ b/docs-md/admission-controller.md
@@ -9,7 +9,7 @@ configuration through dashboard visibility, but to actually enforce it with this
 Note that Polaris will not alter your workloads, only block workloads that don't conform to the configured policies.
 
 ## Installation
-A valid TLS certificate is required for the Polaris Validating Webhook. If you have cert-manager installed in your cluster then the helm install below will work.
+A valid TLS certificate is required for the Polaris Validating Webhook. If you have cert-manager installed in your cluster then the install methods below will work.
 
 If you don't use cert-manager, you'll need to:
 


### PR DESCRIPTION
Recommend updating the install document to be more clear about the use of cert-manager and also updating the name of the  helm chart repository to reflect "fairwinds" rather than "fairwindsOps".