### PR TITLE
change how controller checks are handled

### DIFF
--- a/checks/multipleReplicasForDeployment.yaml
+++ b/checks/multipleReplicasForDeployment.yaml
@@ -8,19 +8,14 @@ controllers:
 schema:
   '$schema': http://json-schema.org/draft-07/schema
   type: object
-  required: 
-  - Object
+  required:
+  - spec
   properties:
-    Object:
+    spec:
       type: object
       required:
-      - spec
+      - replicas
       properties:
-        spec:
-          type: object
-          required:
-          - replicas
-          properties:
-            replicas:
-              type: integer
-              minimum: 2
+        replicas:
+          type: integer
+          minimum: 2

--- a/docs-md/changelog.md
+++ b/docs-md/changelog.md
@@ -1,6 +1,12 @@
 ---
 sidebarDepth: 0
 ---
+## Upcoming
+* **Breaking** - fixed inconsistency in how controller-level checks are handled
+
+## 2.0.1
+* Fixed Polaris deployment process
+
 ## 2.0.0
 * Standardize categories of checks into Security, Reliability, and Efficiency
 * Changes to the dashboard UI

--- a/pkg/kube/workload.go
+++ b/pkg/kube/workload.go
@@ -25,19 +25,6 @@ type GenericWorkload struct {
 	OriginalObjectJSON []byte
 }
 
-func getJSONFromUnstructured(unst *unstructured.Unstructured) ([]byte, error) {
-	b, err := json.Marshal(unst)
-	if err != nil {
-		return nil, err
-	}
-	parsed := map[string]interface{}{}
-	err = json.Unmarshal(b, &parsed)
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(parsed["Object"])
-}
-
 // NewGenericWorkloadFromUnstructured creates a workload from an unstructured.Unstructured
 func NewGenericWorkloadFromUnstructured(kind string, unst *unstructured.Unstructured) (GenericWorkload, error) {
 	workload := GenericWorkload{
@@ -50,7 +37,7 @@ func NewGenericWorkloadFromUnstructured(kind string, unst *unstructured.Unstruct
 	}
 	workload.ObjectMeta = objMeta
 
-	b, err := getJSONFromUnstructured(unst)
+	b, err := json.Marshal(unst)
 	if err != nil {
 		return workload, err
 	}
@@ -150,7 +137,7 @@ func newGenericWorkload(ctx context.Context, podResource kubeAPICoreV1.Pod, dyna
 
 	if lastKey != "" {
 		unst := objectCache[lastKey]
-		bytes, err := getJSONFromUnstructured(&unst)
+		bytes, err := json.Marshal(&unst)
 		if err != nil {
 			return workload, err
 		}

--- a/pkg/kube/workload.go
+++ b/pkg/kube/workload.go
@@ -25,6 +25,19 @@ type GenericWorkload struct {
 	OriginalObjectJSON []byte
 }
 
+func getJSONFromUnstructured(unst *unstructured.Unstructured) ([]byte, error) {
+	b, err := json.Marshal(unst)
+	if err != nil {
+		return nil, err
+	}
+	parsed := map[string]interface{}{}
+	err = json.Unmarshal(b, &parsed)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(parsed["Object"])
+}
+
 // NewGenericWorkloadFromUnstructured creates a workload from an unstructured.Unstructured
 func NewGenericWorkloadFromUnstructured(kind string, unst *unstructured.Unstructured) (GenericWorkload, error) {
 	workload := GenericWorkload{
@@ -37,7 +50,7 @@ func NewGenericWorkloadFromUnstructured(kind string, unst *unstructured.Unstruct
 	}
 	workload.ObjectMeta = objMeta
 
-	b, err := json.Marshal(unst)
+	b, err := getJSONFromUnstructured(unst)
 	if err != nil {
 		return workload, err
 	}
@@ -136,7 +149,8 @@ func newGenericWorkload(ctx context.Context, podResource kubeAPICoreV1.Pod, dyna
 	}
 
 	if lastKey != "" {
-		bytes, err := json.Marshal(objectCache[lastKey])
+		unst := objectCache[lastKey]
+		bytes, err := getJSONFromUnstructured(&unst)
 		if err != nil {
 			return workload, err
 		}


### PR DESCRIPTION
This fixes an inconsistency in how controller-level checks are handled between IaC and in-cluster resources.

The in-cluster resources had an `Object` wrapper around the JSON - this removes that.

This will need a major version bump.

Still working on testing this properly - our k8s mocks aren't quite working right.