### PR TITLE
fix checks for k8s defaults

### DIFF
--- a/checks/insecureCapabilities.yaml
+++ b/checks/insecureCapabilities.yaml
@@ -5,27 +5,53 @@ target: Container
 schema:
   '$schema': http://json-schema.org/draft-07/schema
   type: object
+  required:
+  - securityContext
   properties:
     securityContext:
       type: object
+      required:
+      - capabilities
       properties:
         capabilities:
           type: object
+          required:
+          - drop
           properties:
-            add:
-              enum:
-              - CHOWN
-              - DAC_OVERRIDE
-              - FSETID
-              - FOWNER
-              - MKNOD
-              - NET_RAW
-              - SETGID
-              - SETUID
-              - SETFCAP
-              - SETPCAP
-              - NET_BIND_SERVICE
-              - SYS_CHROOT
-              - KILL
-              - AUDIT_WRITE
+            drop:
+              type: array
+              oneOf:
+              - contains:
+                  const: ALL
+              - allOf:
+                - contains:
+                    const: NET_ADMIN
+                - contains:
+                    const: CHOWN
+                - contains:
+                    const: DAC_OVERRIDE
+                - contains:
+                    const: FSETID
+                - contains:
+                    const: FOWNER
+                - contains:
+                    const: MKNOD
+                - contains:
+                    const: NET_RAW
+                - contains:
+                    const: SETGID
+                - contains:
+                    const: SETUID
+                - contains:
+                    const: SETFCAP
+                - contains:
+                    const: SETPCAP
+                - contains:
+                    const: NET_BIND_SERVICE
+                - contains:
+                    const: SYS_CHROOT
+                - contains:
+                    const: KILL
+                - contains:
+                    const: AUDIT_WRITE
 

--- a/checks/privilegeEscalationAllowed.yaml
+++ b/checks/privilegeEscalationAllowed.yaml
@@ -5,9 +5,12 @@ target: Container
 schema:
   '$schema': http://json-schema.org/draft-07/schema
   type: object
+  required:
+  - securityContext
   properties:
     securityContext:
+      required:
+      - allowPrivilegeEscalation
       properties:
         allowPrivilegeEscalation:
-          not:
-            const: true
+          const: false

--- a/pkg/validator/container_test.go
+++ b/pkg/validator/container_test.go
@@ -561,8 +561,8 @@ func TestValidateSecurity(t *testing.T) {
 				Category: "Security",
 			}, {
 				ID:       "insecureCapabilities",
-				Message:  "Container does not have any insecure capabilities",
-				Success:  true,
+				Message:  "Container should not have insecure capabilities",
+				Success:  false,
 				Severity: "warning",
 				Category: "Security",
 			}, {
@@ -739,8 +739,8 @@ func TestValidateSecurity(t *testing.T) {
 				Category: "Security",
 			}, {
 				ID:       "insecureCapabilities",
-				Message:  "Container does not have any insecure capabilities",
-				Success:  true,
+				Message:  "Container should not have insecure capabilities",
+				Success:  false,
 				Severity: "warning",
 				Category: "Security",
 			}},
@@ -758,8 +758,8 @@ func TestValidateSecurity(t *testing.T) {
 				Category: "Security",
 			}, {
 				ID:       "insecureCapabilities",
-				Message:  "Container does not have any insecure capabilities",
-				Success:  true,
+				Message:  "Container should not have insecure capabilities",
+				Success:  false,
 				Severity: "danger",
 				Category: "Security",
 			}, {

--- a/pkg/validator/container_test.go
+++ b/pkg/validator/container_test.go
@@ -555,8 +555,8 @@ func TestValidateSecurity(t *testing.T) {
 				Category: "Security",
 			}, {
 				ID:       "privilegeEscalationAllowed",
-				Message:  "Privilege escalation not allowed",
-				Success:  true,
+				Message:  "Privilege escalation should not be allowed",
+				Success:  false,
 				Severity: "danger",
 				Category: "Security",
 			}, {

--- a/test/checks/insecureCapabilities/failure.drop-most.yaml
+++ b/test/checks/insecureCapabilities/failure.drop-most.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    env: test
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    securityContext:
+      capabilities:
+        drop:
+          - NET_ADMIN
+          - CHOWN
+          - DAC_OVERRIDE
+          - FSETID
+          - FOWNER
+          - MKNOD
+          - NET_RAW
+          - SETGID
+          - SETUID
+          - SETFCAP
+          - SETPCAP
+          - NET_BIND_SERVICE
+          - SYS_CHROOT
+          - KILL
+
+

--- a/test/checks/insecureCapabilities/failure.yaml
+++ b/test/checks/insecureCapabilities/failure.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    env: test
+spec:
+  containers:
+  - name: nginx
+    image: nginx

--- a/test/checks/insecureCapabilities/success.drop.yaml
+++ b/test/checks/insecureCapabilities/success.drop.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    env: test
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    securityContext:
+      capabilities:
+        drop:
+          - ALL

--- a/test/checks/insecureCapabilities/success.yaml
+++ b/test/checks/insecureCapabilities/success.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    env: test
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    securityContext:
+      capabilities:
+        drop:
+          - NET_ADMIN
+          - CHOWN
+          - DAC_OVERRIDE
+          - FSETID
+          - FOWNER
+          - MKNOD
+          - NET_RAW
+          - SETGID
+          - SETUID
+          - SETFCAP
+          - SETPCAP
+          - NET_BIND_SERVICE
+          - SYS_CHROOT
+          - KILL
+          - AUDIT_WRITE
+

--- a/test/checks/privilegeEscalationAllowed/failure.unspecified.yaml
+++ b/test/checks/privilegeEscalationAllowed/failure.unspecified.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    env: test
+spec:
+  containers:
+  - name: nginx
+    image: nginx

--- a/test/checks/privilegeEscalationAllowed/failure.yaml
+++ b/test/checks/privilegeEscalationAllowed/failure.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    env: test
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    securityContext:
+      allowPrivilegeEscalation: true
+

--- a/test/checks/privilegeEscalationAllowed/success.yaml
+++ b/test/checks/privilegeEscalationAllowed/success.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    env: test
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    securityContext:
+      allowPrivilegeEscalation: false


### PR DESCRIPTION
These capabilities are on-by-default, so they need to be dropped, not just not-added.