### PR TITLE
bounce out once we hit a type we know to avoid CRD problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Binaries for programs and plugins
+.go-version
 *.exe
 *.exe~
 *.dll

--- a/pkg/kube/resource.go
+++ b/pkg/kube/resource.go
@@ -114,6 +114,18 @@ func ResolveControllerFromPod(ctx context.Context, podResource kubeAPICoreV1.Pod
 	return workload, err
 }
 
+func isFinalKind(kind string) bool {
+	switch kind {
+		case
+			"Deployment",
+			"CronJob",
+			"StatefulSet",
+			"DaemonSet":
+			return true
+		}
+	return false
+	}
+
 func resolveControllerFromPod(ctx context.Context, podResource kubeAPICoreV1.Pod, dynamicClient *dynamic.Interface, restMapper *meta.RESTMapper, objectCache map[string]unstructured.Unstructured) (GenericResource, error) {
 	podWorkload, err := NewGenericResourceFromPod(podResource, nil)
 	if err != nil {
@@ -155,6 +167,9 @@ func resolveControllerFromPod(ctx context.Context, podResource kubeAPICoreV1.Pod
 		}
 		topMeta = objMeta
 		owners = abstractObject.GetOwnerReferences()
+		if isFinalKind(topKind) {
+			break
+		}
 	}
 
 	if lastKey != "" {


### PR DESCRIPTION
This PR fixes #

## Checklist
* [X] I have signed the CLA
* [X] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
CRD's cause issues with finding out the pod security contexts of them (since they might be wrapped in a different format than "containers" array

### What changes did you make?
After discussion on slack, added an exclusion list for quick exiting at final state for deployments, daemonsets, cronjobs, etc...

ref: https://fairwindscommunity.slack.com/archives/CURU6LA91/p1647271688336659

### What alternative solution should we consider, if any?
Parse and dissect the meta data from a release of a helm chart, or work backwards from parents back to children once no resources are discovered on the parent chart.