### PR TITLE
Nobletrout/add kubectx support

### DIFF
--- a/cmd/polaris/root.go
+++ b/cmd/polaris/root.go
@@ -29,6 +29,7 @@ var disallowExemptions, disallowConfigExemptions, disallowAnnotationExemptions b
 var logLevel string
 var auditPath string
 var displayName string
+var kubeContext string
 
 var (
 	version string
@@ -37,6 +38,7 @@ var (
 func init() {
 	// Flags
 	rootCmd.PersistentFlags().StringVarP(&configPath, "config", "c", "", "Location of Polaris configuration file.")
+	rootCmd.PersistentFlags().StringVarP(&kubeContext, "context", "x", "", "Set the kube context.")
 	rootCmd.PersistentFlags().BoolVarP(&disallowExemptions, "disallow-exemptions", "", false, "Disallow any configured exemption.")
 	rootCmd.PersistentFlags().BoolVarP(&disallowConfigExemptions, "disallow-config-exemptions", "", false, "Disallow exemptions set within the configuration file.")
 	rootCmd.PersistentFlags().BoolVarP(&disallowAnnotationExemptions, "disallow-annotation-exemptions", "", false, "Disallow any exemption defined as a controller annotation.")
@@ -68,6 +70,7 @@ var rootCmd = &cobra.Command{
 		config.DisallowExemptions = disallowExemptions
 		config.DisallowConfigExemptions = disallowConfigExemptions
 		config.DisallowAnnotationExemptions = disallowAnnotationExemptions
+		config.KubeContext = kubeContext
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		logrus.Error("You must specify a sub-command.")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,6 +20,7 @@ webhook
 
 # global flags
 -c, --config string                    Location of Polaris configuration file.
+-x, --context string                   Set the kube context.
     --disallow-exemptions              Disallow any exemptions from configuration file.
     --disallow-config-exemptions       Disallow exemptions set within the configuration file.
     --disallow-annotation-exemptions   Disallow any exemption defined as a controller annotation.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,6 +36,7 @@ type Configuration struct {
 	DisallowExemptions           bool                   `json:"disallowExemptions"`
 	DisallowConfigExemptions     bool                   `json:"disallowConfigExemptions"`
 	DisallowAnnotationExemptions bool                   `json:"disallowAnnotationExemptions"`
+	KubeContext                  string                 `json:"kubeContext"`
 }
 
 // Exemption represents an exemption to normal rules

--- a/pkg/kube/resources.go
+++ b/pkg/kube/resources.go
@@ -213,7 +213,7 @@ func CreateResourceProviderFromPath(directory string) (*ResourceProvider, error)
 
 // CreateResourceProviderFromCluster creates a new ResourceProvider using live data from a cluster
 func CreateResourceProviderFromCluster(ctx context.Context, c conf.Configuration) (*ResourceProvider, error) {
-	kubeConf, configError := config.GetConfig()
+	kubeConf, configError := config.GetConfigWithContext(c.KubeContext)
 	if configError != nil {
 		logrus.Errorf("Error fetching KubeConfig: %v", configError)
 		return nil, configError


### PR DESCRIPTION
This PR fixes #699 

## Checklist
* [X] I have signed the CLA
* [X] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
add kubecontext selector. I need this feature as well so I added it.
### What changes did you make?
Modified config and changed the API for selecting a context.
### What alternative solution should we consider, if any?
use an environment variable.
Wait for upstream to add a flag.
