### PR TITLE
audit check specific checks when passing checks args

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -38,6 +38,7 @@ webhook
 
 # audit flags
     --audit-path string               If specified, audits one or more YAML files instead of a cluster.
+    --checks stringArray              Optional flag to specify specific checks to check
     --color                           Whether to use color in pretty format. (default true)
     --display-name string             An optional identifier for the audit.
 -f, --format string                   Output format for results - json, yaml, pretty, or score. (default "json")


### PR DESCRIPTION
Signed-off-by: krrrr38 <k.kaizu38@gmail.com>

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

audit command should check only specific checks

### What changes did you make?

In https://github.com/FairwindsOps/polaris/pull/712, added new `checks` args into audit command, but not used.

I change it as string slice variable and change check severity as Ignored when passing checks args.

### What alternative solution should we consider, if any?

N/A


### QA

<details>
<summary>before: not filtered checks</summary>

```
> go run main.go audit -f pretty --audit-path /path/to/templatesNodeSelectorNodeTypeWorkflowTemplate/success.yaml --config /path/to/.polaris.yaml --set-exit-code-on-danger --log-level error --checks templatesNodeSelectorNodeTypeWorkflowTemplate,b --checks a

Polaris audited Path /path/to/templatesNodeSelectorNodeTypeWorkflowTemplate/success.yaml at 2022-03-31T09:11:39+09:00
    Nodes: 0 | Namespaces: 0 | Controllers: 0
    Final score: 50

WorkflowTemplate single-template-success
    templatesNodeSelectorNodeTypeWorkflowTemplate 🎉 Success
        Reliability - Workflow must on on nodeSelector.node-type:batch
    workflowMetadataLabelsWorkflowTemplate ❌ Danger
        Reliability - Should have all required labels [owner, workflow-name, tenant-id, client-id]

WorkflowTemplate multiple-template-success
    templatesNodeSelectorNodeTypeWorkflowTemplate 🎉 Success
        Reliability - Workflow must on on nodeSelector.node-type:batch
    workflowMetadataLabelsWorkflowTemplate ❌ Danger
        Reliability - Should have all required labels [owner, workflow-name, tenant-id, client-id]

exit status 3
```

</details>

<details>
<summary>after: filtered checks</summary>

```sh
> go run main.go audit -f pretty --audit-path /path/to/templatesNodeSelectorNodeTypeWorkflowTemplate/success.yaml --config /path/to/.polaris.yaml --set-exit-code-on-danger --log-level error --checks templatesNodeSelectorNodeTypeWorkflowTemplate,b --checks a


Polaris audited Path /path/to/templatesNodeSelectorNodeTypeWorkflowTemplate/success.yaml at 2022-03-31T09:10:24+09:00
    Nodes: 0 | Namespaces: 0 | Controllers: 0
    Final score: 100

WorkflowTemplate single-template-success
    templatesNodeSelectorNodeTypeWorkflowTemplate 🎉 Success
        Reliability - Workflow must on on nodeSelector.node-type:batch

WorkflowTemplate multiple-template-success
    templatesNodeSelectorNodeTypeWorkflowTemplate 🎉 Success
        Reliability - Workflow must on on nodeSelector.node-type:batch
```

</details>