### PR TITLE
Added Mutation webhook 

### DIFF
--- a/cmd/polaris/webhook.go
+++ b/cmd/polaris/webhook.go
@@ -63,7 +63,8 @@ var webhookCmd = &cobra.Command{
 
 		// Iterate all the configurations supported controllers to scan and register them for webhooks
 		// Should only register controllers that are configured to be scanned
-		fwebhook.NewWebhook(mgr, fwebhook.Validator{Config: config, Client: mgr.GetClient()})
+		fwebhook.NewValidateWebhook(mgr, fwebhook.Validator{Config: config, Client: mgr.GetClient()})
+		fwebhook.NewMutateWebhook(mgr, fwebhook.Mutator{Config: config, Client: mgr.GetClient()})
 
 		logrus.Infof("Polaris webhook server listening on port %d", webhookPort)
 		if err := mgr.Start(signals.SetupSignalHandler()); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,8 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
+require gomodules.xyz/jsonpatch/v2 v2.2.0
+
 require (
 	cloud.google.com/go v0.81.0 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
@@ -72,7 +74,6 @@ require (
 	golang.org/x/sys v0.0.0-20211029165221-6e7872819dc8 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
-	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/qri-io/jsonschema"
 	"github.com/thoas/go-funk"
+	"gomodules.xyz/jsonpatch/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	k8sYaml "k8s.io/apimachinery/pkg/util/yaml"
@@ -71,7 +72,7 @@ type SchemaCheck struct {
 	AdditionalSchemas       map[string]map[string]interface{} `yaml:"additionalSchemas" json:"additionalSchemas"`
 	AdditionalSchemaStrings map[string]string                 `yaml:"additionalSchemaStrings" json:"additionalSchemaStrings"`
 	AdditionalValidators    map[string]jsonschema.RootSchema  `yaml:"-" json:"-"`
-	Mutations               []map[string]interface{}          `yaml:"mutations" json:"mutations"`
+	Mutations               []jsonpatch.Operation             `yaml:"mutations" json:"mutations"`
 	Comments                []MutationComment                 `yaml:"comments" json:"comments"`
 }
 

--- a/pkg/validator/output.go
+++ b/pkg/validator/output.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/thoas/go-funk"
+	"gomodules.xyz/jsonpatch/v2"
 
 	"github.com/fairwindsops/polaris/pkg/config"
 )
@@ -78,7 +79,7 @@ type ResultMessage struct {
 	Success   bool
 	Severity  config.Severity
 	Category  string
-	Mutations []map[string]interface{}
+	Mutations []jsonpatch.Operation
 	Comments  []config.MutationComment
 }
 

--- a/pkg/validator/schema.go
+++ b/pkg/validator/schema.go
@@ -23,6 +23,7 @@ import (
 	"github.com/qri-io/jsonschema"
 	"github.com/sirupsen/logrus"
 	"github.com/thoas/go-funk"
+	"gomodules.xyz/jsonpatch/v2"
 	corev1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -317,7 +318,7 @@ func applySchemaCheck(conf *config.Configuration, checkID string, test schemaTes
 				mutationCopy := deepCopyMutation(mutation)
 				mutationCopy["path"] = prefix + mutationCopy["path"].(string)
 				return mutationCopy
-			}).([]map[string]interface{})
+			}).([]jsonpatch.Operation)
 			result.Mutations = mutations
 			result.Comments = check.Comments
 		}

--- a/pkg/validator/schema.go
+++ b/pkg/validator/schema.go
@@ -314,9 +314,9 @@ func applySchemaCheck(conf *config.Configuration, checkID string, test schemaTes
 	result := makeResult(conf, check, passes, issues)
 	if !passes {
 		if funk.Contains(conf.Mutations, checkID) {
-			mutations := funk.Map(check.Mutations, func(mutation map[string]interface{}) map[string]interface{} {
+			mutations := funk.Map(check.Mutations, func(mutation jsonpatch.Operation) jsonpatch.Operation {
 				mutationCopy := deepCopyMutation(mutation)
-				mutationCopy["path"] = prefix + mutationCopy["path"].(string)
+				mutationCopy.Path = prefix + mutationCopy.Path
 				return mutationCopy
 			}).([]jsonpatch.Operation)
 			result.Mutations = mutations
@@ -335,10 +335,11 @@ func getSortedKeys(m map[string]config.Severity) []string {
 	return keys
 }
 
-func deepCopyMutation(source map[string]interface{}) map[string]interface{} {
-	destination := map[string]interface{}{}
-	for key, value := range source {
-		destination[key] = value
+func deepCopyMutation(source jsonpatch.Operation) jsonpatch.Operation {
+	destination := jsonpatch.Operation{
+		Operation: source.Operation,
+		Path:      source.Path,
+		Value:     source.Value,
 	}
 	return destination
 }

--- a/pkg/webhook/mutate.go
+++ b/pkg/webhook/mutate.go
@@ -1,0 +1,63 @@
+// Copyright 2022 FairwindsOps Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook
+
+import (
+	"context"
+
+	"github.com/fairwindsops/polaris/pkg/config"
+	"github.com/fairwindsops/polaris/pkg/mutation"
+	"github.com/sirupsen/logrus"
+	"gomodules.xyz/jsonpatch/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// Mutator mutate k8s resources.
+type Mutator struct {
+	Client  client.Client
+	Config  config.Configuration
+	decoder *admission.Decoder
+}
+
+var _ admission.Handler = &Mutator{}
+
+// NewMutateWebhook creates a mutating admission webhook for the apiType.
+func NewMutateWebhook(mgr manager.Manager, mutator Mutator) {
+	path := "/mutate"
+
+	mgr.GetWebhookServer().Register(path, &webhook.Admission{Handler: &mutator})
+}
+
+func (m *Mutator) mutate(req admission.Request) ([]jsonpatch.Operation, error) {
+	results, err := getValidateResults(req.AdmissionRequest.Kind.Kind, m.decoder, req, m.Config)
+	if err != nil {
+		return nil, err
+	}
+	patches, _ := mutation.GetMutationsAndCommentsFromResult(results)
+	return patches, nil
+}
+
+// Handle for Validator to run validation checks.
+func (m *Mutator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	logrus.Info("Starting request")
+	patches, err := m.mutate(req)
+	if err != nil {
+		return admission.Errored(403, err)
+	}
+	return admission.Patched("", patches...)
+}

--- a/pkg/webhook/mutate.go
+++ b/pkg/webhook/mutate.go
@@ -59,5 +59,8 @@ func (m *Mutator) Handle(ctx context.Context, req admission.Request) admission.R
 	if err != nil {
 		return admission.Errored(403, err)
 	}
+	if patches == nil {
+		return admission.Allowed("Allowed")
+	}
 	return admission.Patched("", patches...)
 }


### PR DESCRIPTION
This PR fixes #
It adds `/mutate`  endpoint for mutating Kubernetes resources.
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Goal is to be able to mutate k8s resources based on the rules and mutations defined.
### What changes did you make?

### What alternative solution should we consider, if any?

