### PR TITLE
passing the actual path of Polaris to GITHUB_PATH

### DIFF
--- a/.github/actions/setup-polaris/get_polaris.sh
+++ b/.github/actions/setup-polaris/get_polaris.sh
@@ -16,5 +16,5 @@ curl -LJ -o $TARGET_FILE $POLARIS_URL
 mkdir polaris
 tar -xzf $TARGET_FILE -C polaris
 rm $TARGET_FILE
-echo "polaris" >> $GITHUB_PATH
+echo "$(pwd)/polaris/polaris" >> $GITHUB_PATH
 echo "::set-output name=version::$INPUT_VERSION"

--- a/.github/actions/setup-polaris/get_polaris.sh
+++ b/.github/actions/setup-polaris/get_polaris.sh
@@ -16,5 +16,5 @@ curl -LJ -o $TARGET_FILE $POLARIS_URL
 mkdir polaris
 tar -xzf $TARGET_FILE -C polaris
 rm $TARGET_FILE
-echo "$(pwd)/polaris/polaris" >> $GITHUB_PATH
+echo "$(pwd)/polaris" >> $GITHUB_PATH
 echo "::set-output name=version::$INPUT_VERSION"


### PR DESCRIPTION
I don't understand how this could have ever worked before, just passing "polaris" to GITHUB_PATH before, not the actual, absolute path?!

This PR fixes #

## Checklist
* [x] I have signed the CLA
* [ ] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

the install script does not work, the polaris executable is not found

### What changes did you make?

passing the actual path to the executable to GITHUB_PATH

### What alternative solution should we consider, if any?

-