### PR TITLE
expose `Polaris.PodSpec` for PodSpec targeted checks

### DIFF
--- a/pkg/kube/resources.go
+++ b/pkg/kube/resources.go
@@ -17,6 +17,7 @@ package kube
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -474,4 +475,18 @@ func (resources *ResourceProvider) addResourceFromString(contents string) error 
 		resources.Resources.addResource(newResource)
 	}
 	return err
+}
+
+// SerializePod converts a typed PodSpec into a map[string]interface{}
+func SerializePod(pod *corev1.PodSpec) (map[string]interface{}, error) {
+	podJSON, err := json.Marshal(pod)
+	if err != nil {
+		return nil, err
+	}
+	podMap := make(map[string]interface{})
+	err = json.Unmarshal(podJSON, &podMap)
+	if err != nil {
+		return nil, err
+	}
+	return podMap, nil
 }

--- a/pkg/validator/schema.go
+++ b/pkg/validator/schema.go
@@ -27,6 +27,7 @@ import (
 	"gomodules.xyz/jsonpatch/v2"
 	corev1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/fairwindsops/polaris/pkg/config"
 	"github.com/fairwindsops/polaris/pkg/kube"
@@ -64,11 +65,34 @@ func resolveCheck(conf *config.Configuration, checkID string, test schemaTestCas
 	if !check.IsActionable(test.Target, test.Resource.Kind, test.IsInitContianer) {
 		return nil, nil
 	}
-	checkPtr, err := check.TemplateForResource(test.Resource.Resource.Object)
+	templateInput, err := getTemplateInput(test)
+	if err != nil {
+		return nil, err
+	}
+	checkPtr, err := check.TemplateForResource(templateInput)
 	if err != nil {
 		return nil, err
 	}
 	return checkPtr, nil
+}
+
+// getTemplateInput augments a schemaTestCase.Resource.Resource.Object with
+// Polaris built-in variables. The result can be used as input for
+// CheckSchema.TemplateForResource().
+func getTemplateInput(test schemaTestCase) (map[string]interface{}, error) {
+	templateInput := test.Resource.Resource.Object
+	templateInput["Polaris"] = make(map[string]interface{})
+	if test.Target == config.TargetPodSpec {
+		podSpecMap, err := kube.SerializePod(test.Resource.PodSpec)
+		if err != nil {
+			return nil, err
+		}
+		err = unstructured.SetNestedMap(templateInput, podSpecMap, "Polaris", "PodSpec")
+		if err != nil {
+			return nil, err
+		}
+	}
+	return templateInput, nil
 }
 
 func makeResult(conf *config.Configuration, check *config.SchemaCheck, passes bool, issues []jsonschema.ValError) ResultMessage {


### PR DESCRIPTION

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Polaris checks that are `target: PodSpec` have reflected the original
resource (such as a pod-controller) in the Go template, instead of
reflecting the pod `spec` field.

### What changes did you make?
This update makes the PodSpec available
in a new template variable `Polaris.PodSpec`.

### What alternative solution should we consider, if any?
I didn't want to significantly change behavior by setting the root template to PodSpec - we could add a warning notice to documentation and phase that change in for the future though.
