### PR TITLE
Add `target PodTemplate` which exposes the full Pod (not only the spec)

### DIFF
--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -41,6 +41,8 @@ const (
 	TargetContainer TargetKind = "Container"
 	// TargetPodSpec points to the pod spec
 	TargetPodSpec TargetKind = "PodSpec"
+	// TargetPodTemplate points to the pod template
+	TargetPodTemplate TargetKind = "PodTemplate"
 )
 
 // HandledTargets is a list of target names that are explicitly handled
@@ -48,6 +50,7 @@ var HandledTargets = []TargetKind{
 	TargetController,
 	TargetContainer,
 	TargetPodSpec,
+	TargetPodTemplate,
 }
 
 // MutationComment is the comments added to a mutated file
@@ -256,6 +259,11 @@ func (check SchemaCheck) TemplateForResource(res interface{}) (*SchemaCheck, err
 // CheckPodSpec checks a pod spec against the schema
 func (check SchemaCheck) CheckPodSpec(pod *corev1.PodSpec) (bool, []jsonschema.ValError, error) {
 	return check.CheckObject(pod)
+}
+
+// CheckPodTemplate checks a pod target against the schema
+func (check SchemaCheck) CheckPodTemplate(podTemplate interface{}) (bool, []jsonschema.ValError, error) {
+	return check.CheckObject(podTemplate)
 }
 
 // CheckController checks a controler's spec against the schema

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -312,12 +312,12 @@ func (check SchemaCheck) CheckAdditionalObjects(groupkind string, objects []inte
 // IsActionable decides if this check applies to a particular target
 func (check SchemaCheck) IsActionable(target TargetKind, kind string, isInit bool) bool {
 	if funk.Contains(HandledTargets, target) {
-		if check.Target != TargetPodTemplate && check.Target != target {
-			return false
+		if check.Target == TargetPodTemplate && target == TargetPodSpec {
+			// A target=PodSpec and check.Target=PodTemplate is expected
+			// because applyPodSchemaChecks() explicitly sets check.Target
+			return true
 		}
-		if check.Target == TargetPodTemplate && target != TargetPodSpec {
-			// A target=PodSpec and check.Target=PodTemplate is expected RE:
-			// ApplyPodSchemaChecks()
+		if check.Target != target {
 			return false
 		}
 	} else if string(check.Target) != kind && !strings.HasSuffix(string(check.Target), "/"+kind) {

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -261,7 +261,7 @@ func (check SchemaCheck) CheckPodSpec(pod *corev1.PodSpec) (bool, []jsonschema.V
 	return check.CheckObject(pod)
 }
 
-// CheckPodTemplate checks a pod target against the schema
+// CheckPodTemplate checks a pod template against the schema
 func (check SchemaCheck) CheckPodTemplate(podTemplate interface{}) (bool, []jsonschema.ValError, error) {
 	return check.CheckObject(podTemplate)
 }
@@ -312,7 +312,12 @@ func (check SchemaCheck) CheckAdditionalObjects(groupkind string, objects []inte
 // IsActionable decides if this check applies to a particular target
 func (check SchemaCheck) IsActionable(target TargetKind, kind string, isInit bool) bool {
 	if funk.Contains(HandledTargets, target) {
-		if check.Target != target {
+		if check.Target != TargetPodTemplate && check.Target != target {
+			return false
+		}
+		if check.Target == TargetPodTemplate && target != TargetPodSpec {
+			// A target=PodSpec and check.Target=PodTemplate is expected RE:
+			// ApplyPodSchemaChecks()
 			return false
 		}
 	} else if string(check.Target) != kind && !strings.HasSuffix(string(check.Target), "/"+kind) {

--- a/pkg/kube/resource.go
+++ b/pkg/kube/resource.go
@@ -110,6 +110,7 @@ func NewGenericResourceFromPod(podResource kubeAPICoreV1.Pod, originalObject int
 		}
 		workload.ObjectMeta = objMeta
 	}
+	workload.PodTemplate = GetPodTemplate(workload.Resource.Object)
 	return workload, nil
 }
 

--- a/pkg/kube/resource.go
+++ b/pkg/kube/resource.go
@@ -35,6 +35,7 @@ type GenericResource struct {
 	ObjectMeta         kubeAPIMetaV1.Object
 	Resource           unstructured.Unstructured
 	PodSpec            *kubeAPICoreV1.PodSpec
+	PodTemplate        interface{}
 	OriginalObjectJSON []byte
 }
 
@@ -53,6 +54,7 @@ func NewGenericResourceFromUnstructured(unst unstructured.Unstructured, podSpecM
 		return workload, err
 	}
 	workload.ObjectMeta = objMeta
+	workload.PodTemplate = GetPodTemplate(unst.UnstructuredContent())
 
 	b, err := json.Marshal(&unst)
 	if err != nil {
@@ -234,6 +236,25 @@ func GetPodSpec(yaml map[string]interface{}) interface{} {
 	}
 	if _, ok := yaml["containers"]; ok {
 		return yaml
+	}
+	return nil
+}
+
+// GetPodTemplate looks inside arbitrary YAML for a Pod template, containing
+// fields `spec.containers`.
+// For example, it returns the `spec.template` level of a Kubernetes Deployment yaml.
+func GetPodTemplate(yaml map[string]interface{}) interface{} {
+	if yamlSpec, ok := yaml["spec"]; ok {
+		if yamlSpecMap, ok := yamlSpec.(map[string]interface{}); ok {
+			if _, ok := yamlSpecMap["containers"]; ok {
+				return yaml
+			}
+		}
+	}
+	for _, podSpecField := range podSpecFields {
+		if childYaml, ok := yaml[podSpecField]; ok {
+			return GetPodTemplate(childYaml.(map[string]interface{}))
+		}
 	}
 	return nil
 }

--- a/pkg/kube/resource.go
+++ b/pkg/kube/resource.go
@@ -86,10 +86,15 @@ func NewGenericResourceFromUnstructured(unst unstructured.Unstructured, podSpecM
 
 // NewGenericResourceFromPod builds a new workload for a given Pod without looking at parents
 func NewGenericResourceFromPod(podResource kubeAPICoreV1.Pod, originalObject interface{}) (GenericResource, error) {
+	podMap, err := SerializePod(&podResource)
+	if err != nil {
+		return GenericResource{}, err
+	}
 	workload := GenericResource{
-		Kind:       "Pod",
-		PodSpec:    &podResource.Spec,
-		ObjectMeta: podResource.ObjectMeta.GetObjectMeta(),
+		Kind:        "Pod",
+		PodSpec:     &podResource.Spec,
+		PodTemplate: podMap,
+		ObjectMeta:  podResource.ObjectMeta.GetObjectMeta(),
 	}
 	if originalObject != nil {
 		bytes, err := json.Marshal(originalObject)
@@ -110,7 +115,6 @@ func NewGenericResourceFromPod(podResource kubeAPICoreV1.Pod, originalObject int
 		}
 		workload.ObjectMeta = objMeta
 	}
-	workload.PodTemplate = GetPodTemplate(workload.Resource.Object)
 	return workload, nil
 }
 

--- a/pkg/kube/resources.go
+++ b/pkg/kube/resources.go
@@ -477,8 +477,22 @@ func (resources *ResourceProvider) addResourceFromString(contents string) error 
 	return err
 }
 
-// SerializePod converts a typed PodSpec into a map[string]interface{}
-func SerializePod(pod *corev1.PodSpec) (map[string]interface{}, error) {
+// SerializePodSpec converts a typed PodSpec into a map[string]interface{}
+func SerializePodSpec(pod *corev1.PodSpec) (map[string]interface{}, error) {
+	podJSON, err := json.Marshal(pod)
+	if err != nil {
+		return nil, err
+	}
+	podMap := make(map[string]interface{})
+	err = json.Unmarshal(podJSON, &podMap)
+	if err != nil {
+		return nil, err
+	}
+	return podMap, nil
+}
+
+// SerializePod converts a typed Pod into a map[string]interface{}
+func SerializePod(pod *corev1.Pod) (map[string]interface{}, error) {
 	podJSON, err := json.Marshal(pod)
 	if err != nil {
 		return nil, err

--- a/pkg/validator/polaris_template_variable_test.go
+++ b/pkg/validator/polaris_template_variable_test.go
@@ -1,0 +1,50 @@
+// Copyright 2019 FairwindsOps Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"testing"
+
+	conf "github.com/fairwindsops/polaris/pkg/config"
+	"github.com/fairwindsops/polaris/pkg/kube"
+	"github.com/fairwindsops/polaris/test"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestGetTemplateInputReturnsPolarisSubKeys(t *testing.T) {
+	pod := test.MockPod() // Includes a container, required by GetPodSpec
+	pod.Spec.NodeName = "testNodeName"
+	pod.ObjectMeta.Name = "testpod"
+	genRes, err := kube.NewGenericResourceFromPod(pod, pod)
+	require.NoError(t, err, "creating new generic resource from a pod")
+	schemaTest := schemaTestCase{
+		Target:   conf.TargetPodSpec, // ends up being set in the case of target: PodTemplate
+		Resource: genRes,
+	}
+
+	templateInput, err := getTemplateInput(schemaTest)
+	require.NoError(t, err, "getting template input from a generic resource")
+	require.NotNil(t, templateInput)
+	nodeName, ok, err := unstructured.NestedString(templateInput, "Polaris", "PodSpec", "nodeName")
+	require.NoError(t, err, "getting Polaris.PodSpec.nodeName from template input")
+	require.True(t, ok, "getting Polaris.PodSpec.nodeName from template input")
+	require.Equal(t, "testNodeName", nodeName, "the nodeName from template output")
+	podName, ok, err := unstructured.NestedString(templateInput, "Polaris", "PodTemplate", "metadata", "name")
+	require.NoError(t, err, "getting Polaris.PodTemplate.metadata.name from template input")
+	require.True(t, ok, "getting Polaris.PodTemplate.metadata.name from template input")
+	require.Equal(t, "testpod", podName, "the pod from template input")
+}

--- a/pkg/validator/schema.go
+++ b/pkg/validator/schema.go
@@ -288,6 +288,9 @@ func applySchemaCheck(conf *config.Configuration, checkID string, test schemaTes
 	} else if check.Target == config.TargetPodSpec {
 		passes, issues, err = check.CheckPodSpec(test.Resource.PodSpec)
 		prefix = getJSONSchemaPrefix(test.Resource.Kind)
+	} else if check.Target == config.TargetPodTemplate {
+		passes, issues, err = check.CheckPodTemplate(test.Resource.PodTemplate)
+		prefix = getJSONSchemaPrefix(test.Resource.Kind)
 	} else if check.Target == config.TargetContainer {
 		containerIndex := funk.IndexOf(test.Resource.PodSpec.Containers, func(value corev1.Container) bool {
 			return value.Name == test.Container.Name

--- a/pkg/validator/schema.go
+++ b/pkg/validator/schema.go
@@ -93,6 +93,12 @@ func getTemplateInput(test schemaTestCase) (map[string]interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
+		if podTemplateMap, ok := test.Resource.PodTemplate.(map[string]interface{}); ok {
+			err := unstructured.SetNestedMap(templateInput, podTemplateMap, "Polaris", "PodTemplate")
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 	return templateInput, nil
 }

--- a/pkg/validator/schema.go
+++ b/pkg/validator/schema.go
@@ -85,7 +85,7 @@ func getTemplateInput(test schemaTestCase) (map[string]interface{}, error) {
 		return nil, nil
 	}
 	if test.Target == config.TargetPodSpec {
-		podSpecMap, err := kube.SerializePod(test.Resource.PodSpec)
+		podSpecMap, err := kube.SerializePodSpec(test.Resource.PodSpec)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR fixes #735 

## Checklist
* [x] I have signed the CLA
* [ ] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Add a `target: PodTemplate` to make the full pod (not only the spec) available to schema-checking.

### What changes did you make?
Added a new target `PodTemplate`, a function `GetPodTemplate` to return the complete pod containing `spec.containers`, and updated other logic to process the new `target: PodTemplate`.

