### PR TITLE
FWI-2422: Fix `resourceKindMap.addResource()` to not assume every Kind has an APIGroup

### DIFF
--- a/pkg/kube/resources.go
+++ b/pkg/kube/resources.go
@@ -59,7 +59,12 @@ type resourceKindMap map[string][]GenericResource
 
 func (rkm resourceKindMap) addResource(r GenericResource) {
 	gvk := r.Resource.GroupVersionKind()
-	key := gvk.Group + "/" + gvk.Kind
+	var key string
+	if gvk.Group != "" {
+		key = gvk.Group + "/" + gvk.Kind
+	} else {
+		key = gvk.Kind
+	}
 	rkm[key] = append(rkm[key], r)
 }
 


### PR DESCRIPTION

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Polaris checks for `additionalSchemaStrings` involving a Kube resource with no APIGroup were failing unexpectedly.

After further troubleshooting, when a Polaris check `additionalSchemaStrings` looks up a Kube resource with no APIGroup (such as ServiceAccount), those resources were not retained in the `ResourceProvider.Resources` (which is a map of `genericResource` keyed on the APIGroup/kind).

### What changes did you make?
Fix `resourceKindMap.addResource()` to not assume every Kind has an APIGroup. 
