### PR TITLE
FWI-2476: Add missingNetworkPolicy, automountServiceAccountToken, and linuxHardening checks

### DIFF
--- a/checks/automountServiceAccountToken.yaml
+++ b/checks/automountServiceAccountToken.yaml
@@ -1,0 +1,36 @@
+successMessage: The ServiceAccount will not be automounted
+failureMessage: The ServiceAccount will be automounted
+category: Security
+target: PodSpec
+schema:
+  '$schema': http://json-schema.org/draft-07/schema
+  type: object
+  required: ["serviceAccountName"]
+  properties:
+    serviceAccountName:
+      type: string
+    automountServiceAccountToken:
+      type: boolean
+      not:
+        const: true
+additionalSchemaStrings:
+  ServiceAccount: |
+    type: object
+    required:
+      - metadata
+      {{ if not (eq .Polaris.PodSpec.automountServiceAccountToken false) }}
+      - automountServiceAccountToken
+      {{ end }}
+    properties:
+      metadata:
+        type: object
+        required: ["name"]
+        properties:
+          name:
+            type: string
+            const: "{{ .Polaris.PodSpec.serviceAccountName }}"
+      {{ if not (eq .Polaris.PodSpec.automountServiceAccountToken false) }}
+      automountServiceAccountToken:
+        type: boolean
+        const: false
+      {{ end }}

--- a/checks/linuxHardening.yaml
+++ b/checks/linuxHardening.yaml
@@ -1,0 +1,89 @@
+successMessage: One of AppArmor, Seccomp, SELinux, or dropping Linux Capabilities are used to restrict containers using unwanted privileges
+FailureMessage: Use one of AppArmor, Seccomp, SELinux, or dropping Linux Capabilities to restrict containers using unwanted privileges
+category: Security
+target: Container
+schemaString: |
+  '$schema': http://json-schema.org/draft-07/schema
+  definitions:
+    podOrContainerSeccompProfile:
+      type: object
+      {{ $podSeccompProfileType := .Polaris.PodSpec.securityContext.seccompProfile.type }}
+      required:
+      {{ if or (not $podSeccompProfileType) (eq $podSeccompProfileType "Unconfined") }}
+        - securityContext
+      {{ end }}
+      properties:
+        securityContext:
+          type: object
+          required:
+          {{ if or (not $podSeccompProfileType) (eq $podSeccompProfileType "Unconfined") }}
+            - seccompProfile
+          {{ end }}
+          properties:
+            seccompProfile:
+              type: object
+              required:
+              {{ if or (not $podSeccompProfileType) (eq $podSeccompProfileType "Unconfined") }}
+                - type
+              {{ end }}
+              properties:
+                type:
+                  type: string
+                  allOf:
+                    - not:
+                        const: "Unconfined"
+                    {{ if or (not $podSeccompProfileType) (eq $podSeccompProfileType "Unconfined") }}
+                    - minLength: 1
+                    {{ end }}
+    podOrContainerSELinuxOptions:
+      type: object
+      {{ $podSELinuxOptions := .Polaris.PodSpec.securityContext.seLinuxOptions }}
+      {{ if not $podSELinuxOptions }}
+      required: ["securityContext"]
+      properties:
+        securityContext:
+          type: object
+          required: ["seLinuxOptions"]
+          properties:
+            seLinuxOptions:
+              type: object
+              minProperties: 1
+      {{ end }}
+    containerDropCapabilities:
+      type: object
+      required: ["securityContext"]
+      properties:
+        securityContext:
+          type: object
+          required: ["capabilities"]
+          properties:
+            capabilities:
+              type: object
+              required: ["drop"]
+              properties:
+                drop:
+                  type: array
+                  minItems: 1
+                add:
+                  type: array
+                  items:
+                    type: string
+                    not:
+                      pattern: '^(?i)ALL$'
+  # End of definitions
+  {{/* Check for AppArmor which uses pod annotations. IF pod fields are missing,
+       require one of the other hardening measures. */}}
+  {{ $annotationName := (print "container.apparmor.security.beta.kubernetes.io/" .Polaris.Container.name) }}
+  {{/* Checking annotations before using index() avoids a nil panic when there are no annotations */}}
+  {{ $annotationExists := false }}
+  {{ if .Polaris.PodTemplate.metadata.annotations }}
+  {{ $annotationExists = index .Polaris "PodTemplate" "metadata" "annotations" $annotationName }}
+  {{ end }}
+  {{ if $annotationExists }}
+  type: object
+  {{ else }}
+  anyOf:
+  - $ref: "#/definitions/podOrContainerSeccompProfile"
+  - $ref: "#/definitions/podOrContainerSELinuxOptions"
+  - $ref: "#/definitions/containerDropCapabilities"
+  {{ end}}

--- a/checks/missingNetworkPolicy.yaml
+++ b/checks/missingNetworkPolicy.yaml
@@ -1,0 +1,49 @@
+successMessage: A NetworkPolicy matches pod labels and contains egress and ingress rules
+failureMessage: A NetworkPolicy should match pod labels and contain applied egress and ingress rules
+category: Security
+target: PodTemplate
+schema:
+  '$schema': http://json-schema.org/draft-07/schema
+  type: object
+  properties:
+    metadata:
+      type: object
+      properties:
+        labels:
+          type: object
+          minProperties: 1
+additionalSchemaStrings:
+  networking.k8s.io/NetworkPolicy: |
+    type: object
+    properties:
+      spec:
+        type: object
+        required: ["podSelector", "egress", "ingress"]
+        properties:
+          podSelector:
+            type: object
+            required: ["matchLabels"]
+            properties:
+              matchLabels:
+                type: object
+                oneOf:
+                {{ range $key, $value := .Polaris.PodTemplate.metadata.labels }}
+                - properties:
+                    "{{ $key }}":
+                      type: string
+                      const: {{ $value }}
+                  required: ["{{ $key }}"]
+                {{ end }}
+          egress:
+            type: array
+            minItems: 1
+          ingress:
+            minItems: 1
+            type: array
+          policyTypes:
+            type: array
+            allOf:
+              - contains:
+                  pattern: '^(?i)Egress$'
+              - contains:
+                  pattern: '^(?i)Ingress$'

--- a/examples/config-full.yaml
+++ b/examples/config-full.yaml
@@ -12,8 +12,11 @@ checks:
   memoryRequestsMissing: warning
   memoryLimitsMissing: warning
   # security
+  automountServiceAccountToken: warning
   hostIPCSet: danger
   hostPIDSet: danger
+  linuxHardening: danger
+  missingNetworkPolicy: warning
   notReadOnlyRootFilesystem: warning
   privilegeEscalationAllowed: danger
   runAsRootAllowed: danger

--- a/pkg/config/checks.go
+++ b/pkg/config/checks.go
@@ -32,6 +32,7 @@ var (
 		"hostIPCSet",
 		"hostPIDSet",
 		"hostNetworkSet",
+		"automountServiceAccountToken",
 		// Container checks
 		"memoryLimitsMissing",
 		"memoryRequestsMissing",
@@ -49,11 +50,13 @@ var (
 		"dangerousCapabilities",
 		"insecureCapabilities",
 		"priorityClassNotSet",
+		"linuxHardening",
 		// Other checks
 		"tlsSettingsMissing",
 		"pdbDisruptionsIsZero",
 		"metadataAndNameMismatched",
 		"missingPodDisruptionBudget",
+		"missingNetworkPolicy",
 	}
 )
 

--- a/test/checks/automountServiceAccountToken/failure.all_true.yaml
+++ b/test/checks/automountServiceAccountToken/failure.all_true.yaml
@@ -1,0 +1,19 @@
+# This fails because automounting is true for both the pod and ServiceAccount.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  automountServiceAccountToken: true
+  serviceAccountName: test
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test
+automountServiceAccountToken: true

--- a/test/checks/automountServiceAccountToken/failure.pod_true_serviceaccount_false.yaml
+++ b/test/checks/automountServiceAccountToken/failure.pod_true_serviceaccount_false.yaml
@@ -1,0 +1,19 @@
+# This fails because automounting is true for the pod, overriding the ServiceAccount.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  automountServiceAccountToken: true
+  serviceAccountName: test
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test
+automountServiceAccountToken: false

--- a/test/checks/automountServiceAccountToken/failure.uses_defaults.yaml
+++ b/test/checks/automountServiceAccountToken/failure.uses_defaults.yaml
@@ -1,0 +1,17 @@
+# This fails because automounting is not disabled anywhere.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  serviceAccountName: test
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test

--- a/test/checks/automountServiceAccountToken/success.pod.yaml
+++ b/test/checks/automountServiceAccountToken/success.pod.yaml
@@ -1,0 +1,19 @@
+# This succeeds because automounting is disabled at the pod.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  automountServiceAccountToken: false
+  serviceAccountName: test
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test
+

--- a/test/checks/automountServiceAccountToken/success.pod_and_serviceaccount.yaml
+++ b/test/checks/automountServiceAccountToken/success.pod_and_serviceaccount.yaml
@@ -1,0 +1,19 @@
+# This succeeds because automounting is disabled at the pod and ServiceAccount.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  automountServiceAccountToken: false
+  serviceAccountName: test
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test
+automountServiceAccountToken: false

--- a/test/checks/automountServiceAccountToken/success.pod_false_serviceaccount_true.yaml
+++ b/test/checks/automountServiceAccountToken/success.pod_false_serviceaccount_true.yaml
@@ -1,0 +1,19 @@
+# This succeeds because automounting is disabled at the pod, overriding the ServiceAccount.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  automountServiceAccountToken: false
+  serviceAccountName: test
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test
+automountServiceAccountToken: true

--- a/test/checks/automountServiceAccountToken/success.serviceaccount.yaml
+++ b/test/checks/automountServiceAccountToken/success.serviceaccount.yaml
@@ -1,0 +1,18 @@
+# This succeeds because automounting is disabled at the ServiceAccount.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  serviceAccountName: test
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test
+automountServiceAccountToken: false

--- a/test/checks/linuxHardening/failure.apparmor_incorrect_annotation_names.yaml
+++ b/test/checks/linuxHardening/failure.apparmor_incorrect_annotation_names.yaml
@@ -1,0 +1,18 @@
+# This fails because the annotation names do not match the containers.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: runtime/default
+    container.apparmor.security.beta.kubernetes.io/container2: runtime/default
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80
+  - name: nginx2
+    image: nginx
+    ports:
+    - containerPort: 81

--- a/test/checks/linuxHardening/failure.drop_capabilities_but_add_all.yaml
+++ b/test/checks/linuxHardening/failure.drop_capabilities_but_add_all.yaml
@@ -1,0 +1,17 @@
+# This fails because ALL capabilities are also added.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    securityContext:
+      capabilities:
+        drop:
+          - ALL
+        add:
+          - all
+    ports:
+    - containerPort: 80

--- a/test/checks/linuxHardening/failure.nothing_is_satisfied.yaml
+++ b/test/checks/linuxHardening/failure.nothing_is_satisfied.yaml
@@ -1,0 +1,11 @@
+# This fails because none of the seccompProfile, seLinuxOptions, AppArmor, or dropping capabilities are present.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80

--- a/test/checks/linuxHardening/failure.seccomp_profile_container_overrides_pod.yaml
+++ b/test/checks/linuxHardening/failure.seccomp_profile_container_overrides_pod.yaml
@@ -1,0 +1,17 @@
+# This fails because the container overrides the pod profile type.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+  - name: nginx
+    securityContext:
+      seccompProfile:
+        type: Unconfined
+    image: nginx
+    ports:
+    - containerPort: 80

--- a/test/checks/linuxHardening/failure.seccomp_profile_pod_missing_type.yaml
+++ b/test/checks/linuxHardening/failure.seccomp_profile_pod_missing_type.yaml
@@ -1,0 +1,13 @@
+# This fails because the pod seccompPRofile is missing the type field.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  securityContext:
+    seccompProfile:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80

--- a/test/checks/linuxHardening/failure.seccomp_profile_pod_unconfined.yaml
+++ b/test/checks/linuxHardening/failure.seccomp_profile_pod_unconfined.yaml
@@ -1,0 +1,14 @@
+# This fails because the container overrides the pod profile type.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  securityContext:
+    seccompProfile:
+      type: Unconfined
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80

--- a/test/checks/linuxHardening/failure.selinux_container_missing_subfield.yaml
+++ b/test/checks/linuxHardening/failure.selinux_container_missing_subfield.yaml
@@ -1,0 +1,13 @@
+# This fails because seLinuxOptions is defined but without any sub-field.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  containers:
+  - name: nginx
+    securityContext:
+      seLinuxOptions:
+    image: nginx
+    ports:
+    - containerPort: 80

--- a/test/checks/linuxHardening/failure.selinux_pod_missing_subfield.yaml
+++ b/test/checks/linuxHardening/failure.selinux_pod_missing_subfield.yaml
@@ -1,0 +1,13 @@
+# This fails because seLinuxOptions is defined but without any sub-field.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  securityContext:
+    seLinuxOptions:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80

--- a/test/checks/linuxHardening/success.apparmor_2_containers.yaml
+++ b/test/checks/linuxHardening/success.apparmor_2_containers.yaml
@@ -1,0 +1,18 @@
+# This succeeds because AppArmor annotations exist matching both container names.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/nginx: runtime/default
+    container.apparmor.security.beta.kubernetes.io/nginx2: runtime/default
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80
+  - name: nginx2
+    image: nginx
+    ports:
+    - containerPort: 81

--- a/test/checks/linuxHardening/success.drop_capabilities.yaml
+++ b/test/checks/linuxHardening/success.drop_capabilities.yaml
@@ -1,0 +1,17 @@
+# This succeeds because SOME capability is dropped, and ALL capabilities are not added.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+        add:
+        - someCapabilities
+    ports:
+    - containerPort: 80

--- a/test/checks/linuxHardening/success.seccomp_profile_container.yaml
+++ b/test/checks/linuxHardening/success.seccomp_profile_container.yaml
@@ -1,0 +1,14 @@
+# This succeeds because a seccomp profile is defined for the container.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  containers:
+  - name: nginx
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
+    image: nginx
+    ports:
+    - containerPort: 80

--- a/test/checks/linuxHardening/success.seccomp_profile_pod.yaml
+++ b/test/checks/linuxHardening/success.seccomp_profile_pod.yaml
@@ -1,0 +1,14 @@
+# This succeeds because a seccomp profile is defined for the pod and not undefined for the container.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80

--- a/test/checks/linuxHardening/success.seccomp_profile_unconfined_for_pod_but_set_for_container.yaml
+++ b/test/checks/linuxHardening/success.seccomp_profile_unconfined_for_pod_but_set_for_container.yaml
@@ -1,0 +1,17 @@
+# This succeeds because the container seccomp profile  overrides the pod Unconfined setting.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  securityContext:
+    seccompProfile:
+      type: Unconfined
+  containers:
+  - name: nginx
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
+    image: nginx
+    ports:
+    - containerPort: 80

--- a/test/checks/linuxHardening/success.selinux_container.yaml
+++ b/test/checks/linuxHardening/success.selinux_container.yaml
@@ -1,0 +1,14 @@
+# This succeeds because seLinuxOptions are defined for the container.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  containers:
+  - name: nginx
+    securityContext:
+      seLinuxOptions:
+        level:   "s0:c123,c456"
+    image: nginx
+    ports:
+    - containerPort: 80

--- a/test/checks/linuxHardening/success.selinux_pod.yaml
+++ b/test/checks/linuxHardening/success.selinux_pod.yaml
@@ -1,0 +1,14 @@
+# This succeeds because seLinuxOptions is defined for the pod.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  securityContext:
+    seLinuxOptions:
+      level:   "s0:c123,c456"
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80

--- a/test/checks/missingNetworkPolicy/failure.netpol_missing_egress_in_policytypes.yaml
+++ b/test/checks/missingNetworkPolicy/failure.netpol_missing_egress_in_policytypes.yaml
@@ -1,0 +1,41 @@
+# This failes because the NetworkPolicy `policyTypes` lacks `Egress`,
+# without which the egress rules will not be applied.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  labels:
+    security: medium
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.23.0
+    ports:
+    - containerPort: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test
+spec:
+  podSelector:
+    matchLabels:
+      security: medium
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    ports:
+    - protocol: TCP
+      port: 8080
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          # Allow outbound with other medium-security pods.
+          security: medium
+    ports:
+    - protocol: TCP
+      port: 80

--- a/test/checks/missingNetworkPolicy/failure.netpol_missing_egress_in_policytypes.yaml
+++ b/test/checks/missingNetworkPolicy/failure.netpol_missing_egress_in_policytypes.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx:1.23.0
+    image: nginx
     ports:
     - containerPort: 80
 ---

--- a/test/checks/missingNetworkPolicy/failure.netpol_missing_egress_rules.yaml
+++ b/test/checks/missingNetworkPolicy/failure.netpol_missing_egress_rules.yaml
@@ -1,0 +1,32 @@
+# This fails because the NetworkPolicy lacks egress rules.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  labels:
+    security: medium
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.23.0
+    ports:
+    - containerPort: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test
+spec:
+  podSelector:
+    matchLabels:
+      security: medium
+  policyTypes:
+  - Egress
+  - Ingress
+  ingress:
+  - from:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    ports:
+    - protocol: TCP
+      port: 8080

--- a/test/checks/missingNetworkPolicy/failure.netpol_missing_egress_rules.yaml
+++ b/test/checks/missingNetworkPolicy/failure.netpol_missing_egress_rules.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx:1.23.0
+    image: nginx
     ports:
     - containerPort: 80
 ---

--- a/test/checks/missingNetworkPolicy/failure.netpol_missing_ingress_in_policytypes.yaml
+++ b/test/checks/missingNetworkPolicy/failure.netpol_missing_ingress_in_policytypes.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx:1.23.0
+    image: nginx
     ports:
     - containerPort: 80
 ---

--- a/test/checks/missingNetworkPolicy/failure.netpol_missing_ingress_in_policytypes.yaml
+++ b/test/checks/missingNetworkPolicy/failure.netpol_missing_ingress_in_policytypes.yaml
@@ -1,0 +1,41 @@
+# This failes because the NetworkPolicy `policyTypes` lacks `Ingress`,
+# without which the egress rules will not be applied.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  labels:
+    security: medium
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.23.0
+    ports:
+    - containerPort: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test
+spec:
+  podSelector:
+    matchLabels:
+      security: medium
+  policyTypes:
+  - Egress
+  ingress:
+  - from:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    ports:
+    - protocol: TCP
+      port: 8080
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          # Allow outbound with other medium-security pods.
+          security: medium
+    ports:
+    - protocol: TCP
+      port: 80

--- a/test/checks/missingNetworkPolicy/failure.netpol_missing_ingress_rules.yaml
+++ b/test/checks/missingNetworkPolicy/failure.netpol_missing_ingress_rules.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx:1.23.0
+    image: nginx
     ports:
     - containerPort: 80
 ---

--- a/test/checks/missingNetworkPolicy/failure.netpol_missing_ingress_rules.yaml
+++ b/test/checks/missingNetworkPolicy/failure.netpol_missing_ingress_rules.yaml
@@ -1,0 +1,34 @@
+# This fails because the NetworkPolicy lacks ingress rules.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  labels:
+    security: medium
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.23.0
+    ports:
+    - containerPort: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test
+spec:
+  podSelector:
+    matchLabels:
+      security: medium
+  policyTypes:
+  - Egress
+  - Ingress
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          # Allow outbound with other medium-security pods.
+          security: medium
+    ports:
+    - protocol: TCP
+      port: 80

--- a/test/checks/missingNetworkPolicy/failure.netpol_targets_wrong_pod_label.yaml
+++ b/test/checks/missingNetworkPolicy/failure.netpol_targets_wrong_pod_label.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx:1.23.0
+    image: nginx
     ports:
     - containerPort: 80
 ---

--- a/test/checks/missingNetworkPolicy/failure.netpol_targets_wrong_pod_label.yaml
+++ b/test/checks/missingNetworkPolicy/failure.netpol_targets_wrong_pod_label.yaml
@@ -1,0 +1,41 @@
+# This fails because the NetworkPolicy matches a label the pod does not have
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  labels:
+    security: medium
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.23.0
+    ports:
+    - containerPort: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test
+spec:
+  podSelector:
+    matchLabels:
+      security: high
+  policyTypes:
+  - Egress
+  - Ingress
+  ingress:
+  - from:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    ports:
+    - protocol: TCP
+      port: 8080
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          # Allow outbound with other medium-security pods.
+          security: medium
+    ports:
+    - protocol: TCP
+      port: 80

--- a/test/checks/missingNetworkPolicy/success.yaml
+++ b/test/checks/missingNetworkPolicy/success.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx:1.23.0
+    image: nginx
     ports:
     - containerPort: 80
 ---

--- a/test/checks/missingNetworkPolicy/success.yaml
+++ b/test/checks/missingNetworkPolicy/success.yaml
@@ -1,0 +1,41 @@
+# This succeeds because the NetworkPolicy contains and enables egress and ingress rules, and targets the pod's label.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  labels:
+    security: medium
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.23.0
+    ports:
+    - containerPort: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test
+spec:
+  podSelector:
+    matchLabels:
+      security: medium
+  policyTypes:
+  - Egress
+  - Ingress
+  ingress:
+  - from:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    ports:
+    - protocol: TCP
+      port: 8080
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          # Allow outbound with other medium-security pods.
+          security: medium
+    ports:
+    - protocol: TCP
+      port: 80

--- a/test/fixtures.go
+++ b/test/fixtures.go
@@ -199,6 +199,7 @@ func SetupTestAPI(objects ...runtime.Object) (kubernetes.Interface, dynamic.Inte
 			APIResources: []metav1.APIResource{
 				{Name: "pods", Namespaced: true, Kind: "Pod"},
 				{Name: "replicationcontrollers", Namespaced: true, Kind: "ReplicationController"},
+				{Name: "serviceaccounts", Namespaced: true, Kind: "ServiceAccount"},
 			},
 		},
 		{
@@ -239,6 +240,7 @@ func SetupTestAPI(objects ...runtime.Object) (kubernetes.Interface, dynamic.Inte
 			GroupVersion: "networking.k8s.io/v1",
 			APIResources: []metav1.APIResource{
 				{Name: "ingresses", Namespaced: true, Kind: "Ingress", Version: "v1"},
+				{Name: "networkpolicies", Namespaced: true, Kind: "NetworkPolicy", Version: "v1"},
 			},
 		},
 		{


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Add checks for

* missingNetworkPolicy - requires a NetworkPolicy that contains applied egress and ingress rules, and targets a Pod label.
* automountServiceAccountToken - requires that auto mounting of a ServiceAccount token is disabled for a Pod, either at the ServiceAccount or Pod level.
* linuxHardening - requires that one of seLinux options, AppArmor, sec comp profile, or dropping Linux capabilities are used to prevent a container from using unwanted privileges. Some of these can be set at the Pod or Container level.
### What changes did you make?
Added the above checks along with success and failure schema test-cases to validate fields which can be set or overridden at the pod and container spec.

Internal Ticket: [FWI-2476](https://fairwinds.myjetbrains.com/youtrack/issue/FWI-2476)