### PR TITLE
FWI-2547: Add checks for RBAC allowing execing or attaching to a Pod

### DIFF
--- a/checks/clusterrolePodExecAttach.yaml
+++ b/checks/clusterrolePodExecAttach.yaml
@@ -1,4 +1,4 @@
-successMessage: The ClusterRole does not allow Pod exec or attach
+successMessage: The ClusterRole does not allow pods/exec or pods/attach
 failureMessage: The ClusterRole allows Pods/exec or pods/attach
 category: Security
 target: rbac.authorization.k8s.io/ClusterRole
@@ -7,6 +7,7 @@ schemaString: |
   type: object
   required: ["metadata", "rules"]
   anyOf:
+    # Do not alert on default ClusterRoles.
     - properties:
         metadata:
           required: ["name"]
@@ -49,5 +50,6 @@ schemaString: |
                     type: string
                     anyOf:
                       - const: '*'
+                      # An exec is also possible by `get`ing a web socket.
                       - const: 'get'
                       - const: 'create'

--- a/checks/clusterrolePodExecAttach.yaml
+++ b/checks/clusterrolePodExecAttach.yaml
@@ -1,0 +1,53 @@
+successMessage: The ClusterRole does not allow Pod exec or attach
+failureMessage: The ClusterRole allows Pods/exec or pods/attach
+category: Security
+target: rbac.authorization.k8s.io/ClusterRole
+schemaString: |
+  '$schema': http://json-schema.org/draft-07/schema
+  type: object
+  required: ["metadata", "rules"]
+  anyOf:
+    - properties:
+        metadata:
+          required: ["name"]
+          properties:
+            name:
+              type: string
+              anyOf:
+                - const: 'admin'
+                - const: "cluster-admin"
+                - const: "edit"
+                - const: "system:aggregate-to-edit"
+                - const: "system:controller:generic-garbage-collector"
+                - const: "system:controller:namespace-controller"
+    - properties:
+        rules:
+          type: array
+          items:
+            type: object
+            not:
+              required: ["apiGroups", "resources", "verbs"]
+              properties:
+                apiGroups:
+                  type: array
+                  contains:
+                    type: string
+                    anyOf:
+                      - const: ""
+                      - const: '*'
+                resources:
+                  type: array
+                  contains:
+                    type: string
+                    anyOf:
+                      - const: '*'
+                      - const: "pods/exec"
+                      - const: "pods/attach"
+                verbs:
+                  type: array
+                  contains:
+                    type: string
+                    anyOf:
+                      - const: '*'
+                      - const: 'get'
+                      - const: 'create'

--- a/checks/clusterrolebindingPodExecAttach.yaml
+++ b/checks/clusterrolebindingPodExecAttach.yaml
@@ -1,5 +1,5 @@
 successMessage: The ClusterRoleBinding does not reference a ClusterRole allowing pods/exec or pods/attach
-failureMessage: The ClusterRoleBinding references a ClusterRole that allows Pods/exec or pods/attach
+failureMessage: The ClusterRoleBinding references a ClusterRole that allows Pods/exec, allows pods/attach, or that does not exist
 category: Security
 target: rbac.authorization.k8s.io/ClusterRoleBinding
 schemaString: |

--- a/checks/clusterrolebindingPodExecAttach.yaml
+++ b/checks/clusterrolebindingPodExecAttach.yaml
@@ -1,4 +1,4 @@
-successMessage: The ClusterRoleBinding does not reference a ClusterRole allowing Pod exec or attach
+successMessage: The ClusterRoleBinding does not reference a ClusterRole allowing pods/exec or pods/attach
 failureMessage: The ClusterRoleBinding references a ClusterRole that allows Pods/exec or pods/attach
 category: Security
 target: rbac.authorization.k8s.io/ClusterRoleBinding
@@ -6,6 +6,7 @@ schemaString: |
   '$schema': http://json-schema.org/draft-07/schema
   type: object
   anyOf:
+    # Do not alert on default ClusterRoleBindings.
     - required: ["metadata"]
       properties:
         metadata:
@@ -35,6 +36,7 @@ schemaString: |
 additionalSchemaStrings:
   rbac.authorization.k8s.io/ClusterRole: |
     type: object
+    # Do not alert on default ClusterRoleBindings.
     {{ if and (ne .metadata.name "cluster-admin") (ne .metadata.name "system:controller:generic-garbage-collector") (ne .metadata.name "system:controller:namespace-controller") }}
     required: ["metadata", "rules"]
     allOf:
@@ -74,6 +76,7 @@ additionalSchemaStrings:
                       type: string
                       anyOf:
                         - const: '*'
+                        # An exec is also possible by `get`ing a web socket.
                         - const: 'get'
                         - const: 'create'
     {{ end }}

--- a/checks/clusterrolebindingPodExecAttach.yaml
+++ b/checks/clusterrolebindingPodExecAttach.yaml
@@ -1,0 +1,79 @@
+successMessage: The ClusterRoleBinding does not reference a ClusterRole allowing Pod exec or attach
+failureMessage: The ClusterRoleBinding references a ClusterRole that allows Pods/exec or pods/attach
+category: Security
+target: rbac.authorization.k8s.io/ClusterRoleBinding
+schemaString: |
+  '$schema': http://json-schema.org/draft-07/schema
+  type: object
+  anyOf:
+    - required: ["metadata"]
+      properties:
+        metadata:
+          type: object
+          required: ["name"]
+          properties:
+            name:
+              type: string
+              anyOf:
+                - const: "cluster-admin"
+                - const: "system:controller:generic-garbage-collector"
+                - const: "system:controller:namespace-controller"
+    - required: ["roleRef"]
+      properties:
+        roleRef:
+          required: ["apiGroup", "kind", "name"]
+          properties:
+            apiGroup:
+              type: string
+              const: "rbac.authorization.k8s.io"
+            kind:
+              type: string
+              const: "ClusterRole"
+            name:
+              type: string
+              minLength: 1
+additionalSchemaStrings:
+  rbac.authorization.k8s.io/ClusterRole: |
+    type: object
+    {{ if and (ne .metadata.name "cluster-admin") (ne .metadata.name "system:controller:generic-garbage-collector") (ne .metadata.name "system:controller:namespace-controller") }}
+    required: ["metadata", "rules"]
+    allOf:
+      - properties:
+          metadata:
+            required: ["name"]
+            properties:
+              name:
+                type: string
+                const: "{{ .roleRef.name }}"
+      - properties:
+          rules:
+            type: array
+            items:
+              type: object
+              not:
+                required: ["apiGroups", "resources", "verbs"]
+                properties:
+                  apiGroups:
+                    type: array
+                    contains:
+                      type: string
+                      anyOf:
+                        - const: ""
+                        - const: '*'
+                  resources:
+                    type: array
+                    contains:
+                      type: string
+                      anyOf:
+                        - const: '*'
+                        - const: "pods/exec"
+                        - const: "pods/attach"
+                  verbs:
+                    type: array
+                    contains:
+                      type: string
+                      anyOf:
+                        - const: '*'
+                        - const: 'get'
+                        - const: 'create'
+    {{ end }}

--- a/checks/rolePodExecAttach.yaml
+++ b/checks/rolePodExecAttach.yaml
@@ -1,0 +1,44 @@
+successMessage: The Role does not allow Pod exec or attach
+failureMessage: The Role allows Pods/exec or pods/attach
+category: Security
+target: rbac.authorization.k8s.io/Role
+schemaString: |
+  '$schema': http://json-schema.org/draft-07/schema
+  type: object
+  required: ["metadata", "rules"]
+  properties:
+    metadata:
+      required: ["name"]
+      properties:
+        name:
+          type: string
+    rules:
+      type: array
+      items:
+        type: object
+        not:
+          required: ["apiGroups", "resources", "verbs"]
+          properties:
+            apiGroups:
+              type: array
+              contains:
+                type: string
+                anyOf:
+                  - const: ""
+                  - const: '*'
+            resources:
+              type: array
+              contains:
+                type: string
+                anyOf:
+                  - const: '*'
+                  - const: "pods/exec"
+                  - const: "pods/attach"
+            verbs:
+              type: array
+              contains:
+                type: string
+                anyOf:
+                  - const: '*'
+                  - const: 'get'
+                  - const: 'create'

--- a/checks/rolePodExecAttach.yaml
+++ b/checks/rolePodExecAttach.yaml
@@ -1,4 +1,4 @@
-successMessage: The Role does not allow Pod exec or attach
+successMessage: The Role does not allow pods/exec or pods/attach
 failureMessage: The Role allows Pods/exec or pods/attach
 category: Security
 target: rbac.authorization.k8s.io/Role
@@ -40,5 +40,6 @@ schemaString: |
                 type: string
                 anyOf:
                   - const: '*'
+                  # An exec is also possible by `get`ing a web socket.
                   - const: 'get'
                   - const: 'create'

--- a/checks/rolebindingClusterRolePodExecAttach.yaml
+++ b/checks/rolebindingClusterRolePodExecAttach.yaml
@@ -6,7 +6,7 @@ schemaString: |
   '$schema': http://json-schema.org/draft-07/schema
   type: object
   anyOf:
-    # Do not alert on default Roles.
+    # Do not alert on default RoleBindings.
     - required: ["metadata"]
       properties:
         metadata:
@@ -19,6 +19,15 @@ schemaString: |
                 - const: "cluster-admin"
                 - const: "system:controller:generic-garbage-collector"
                 - const: "system:controller:namespace-controller"
+    # Pass RoleBindings that point to a Role.
+    - required: ["roleRef"]
+      properties:
+        roleRef:
+          required: ["kind"]
+          properties:
+            kind:
+              type: string
+              const: "Role"
     - required: ["roleRef"]
       properties:
         roleRef:
@@ -36,6 +45,8 @@ schemaString: |
 additionalSchemaStrings:
   rbac.authorization.k8s.io/ClusterRole: |
     type: object
+    # This schema is validated for all roleBindings, regardless of their roleRef.
+    {{ if eq .roleRef.kind "ClusterRole" }}
     # Do not alert on default RoleBindings.
     {{ if and (ne .metadata.name "cluster-admin") (ne .metadata.name "system:controller:generic-garbage-collector") (ne .metadata.name "system:controller:namespace-controller") }}
     required: ["metadata", "rules"]
@@ -79,4 +90,5 @@ additionalSchemaStrings:
                         # An exec is also possible by `get`ing a web socket.
                         - const: 'get'
                         - const: 'create'
+    {{ end }}
     {{ end }}

--- a/checks/rolebindingClusterRolePodExecAttach.yaml
+++ b/checks/rolebindingClusterRolePodExecAttach.yaml
@@ -1,4 +1,4 @@
-successMessage: The RoleBinding does not reference a ClusterRole allowing Pod exec or attach
+successMessage: The RoleBinding does not reference a ClusterRole allowing pods/exec or pods/attach
 failureMessage: The RoleBinding references a ClusterRole that allows Pods/exec or pods/attach
 category: Security
 target: rbac.authorization.k8s.io/RoleBinding
@@ -6,6 +6,7 @@ schemaString: |
   '$schema': http://json-schema.org/draft-07/schema
   type: object
   anyOf:
+    # Do not alert on default Roles.
     - required: ["metadata"]
       properties:
         metadata:
@@ -35,6 +36,7 @@ schemaString: |
 additionalSchemaStrings:
   rbac.authorization.k8s.io/ClusterRole: |
     type: object
+    # Do not alert on default RoleBindings.
     {{ if and (ne .metadata.name "cluster-admin") (ne .metadata.name "system:controller:generic-garbage-collector") (ne .metadata.name "system:controller:namespace-controller") }}
     required: ["metadata", "rules"]
     allOf:
@@ -74,6 +76,7 @@ additionalSchemaStrings:
                       type: string
                       anyOf:
                         - const: '*'
+                        # An exec is also possible by `get`ing a web socket.
                         - const: 'get'
                         - const: 'create'
     {{ end }}

--- a/checks/rolebindingClusterRolePodExecAttach.yaml
+++ b/checks/rolebindingClusterRolePodExecAttach.yaml
@@ -6,19 +6,6 @@ schemaString: |
   '$schema': http://json-schema.org/draft-07/schema
   type: object
   anyOf:
-    # Do not alert on default RoleBindings.
-    - required: ["metadata"]
-      properties:
-        metadata:
-          type: object
-          required: ["name"]
-          properties:
-            name:
-              type: string
-              anyOf:
-                - const: "cluster-admin"
-                - const: "system:controller:generic-garbage-collector"
-                - const: "system:controller:namespace-controller"
     # Pass RoleBindings that point to a Role.
     - required: ["roleRef"]
       properties:
@@ -47,8 +34,6 @@ additionalSchemaStrings:
     type: object
     # This schema is validated for all roleBindings, regardless of their roleRef.
     {{ if eq .roleRef.kind "ClusterRole" }}
-    # Do not alert on default RoleBindings.
-    {{ if and (ne .metadata.name "cluster-admin") (ne .metadata.name "system:controller:generic-garbage-collector") (ne .metadata.name "system:controller:namespace-controller") }}
     required: ["metadata", "rules"]
     allOf:
       - properties:
@@ -90,5 +75,4 @@ additionalSchemaStrings:
                         # An exec is also possible by `get`ing a web socket.
                         - const: 'get'
                         - const: 'create'
-    {{ end }}
     {{ end }}

--- a/checks/rolebindingClusterRolePodExecAttach.yaml
+++ b/checks/rolebindingClusterRolePodExecAttach.yaml
@@ -1,5 +1,5 @@
 successMessage: The RoleBinding does not reference a ClusterRole allowing pods/exec or pods/attach
-failureMessage: The RoleBinding references a ClusterRole that allows Pods/exec or pods/attach
+failureMessage: The RoleBinding references a ClusterRole that allows Pods/exec, allows pods/attach, or that does not exist
 category: Security
 target: rbac.authorization.k8s.io/RoleBinding
 schemaString: |

--- a/checks/rolebindingClusterRolePodExecAttach.yaml
+++ b/checks/rolebindingClusterRolePodExecAttach.yaml
@@ -1,0 +1,79 @@
+successMessage: The RoleBinding does not reference a ClusterRole allowing Pod exec or attach
+failureMessage: The RoleBinding references a ClusterRole that allows Pods/exec or pods/attach
+category: Security
+target: rbac.authorization.k8s.io/RoleBinding
+schemaString: |
+  '$schema': http://json-schema.org/draft-07/schema
+  type: object
+  anyOf:
+    - required: ["metadata"]
+      properties:
+        metadata:
+          type: object
+          required: ["name"]
+          properties:
+            name:
+              type: string
+              anyOf:
+                - const: "cluster-admin"
+                - const: "system:controller:generic-garbage-collector"
+                - const: "system:controller:namespace-controller"
+    - required: ["roleRef"]
+      properties:
+        roleRef:
+          required: ["apiGroup", "kind", "name"]
+          properties:
+            apiGroup:
+              type: string
+              const: "rbac.authorization.k8s.io"
+            kind:
+              type: string
+              const: "ClusterRole"
+            name:
+              type: string
+              minLength: 1
+additionalSchemaStrings:
+  rbac.authorization.k8s.io/ClusterRole: |
+    type: object
+    {{ if and (ne .metadata.name "cluster-admin") (ne .metadata.name "system:controller:generic-garbage-collector") (ne .metadata.name "system:controller:namespace-controller") }}
+    required: ["metadata", "rules"]
+    allOf:
+      - properties:
+          metadata:
+            required: ["name"]
+            properties:
+              name:
+                type: string
+                const: "{{ .roleRef.name }}"
+      - properties:
+          rules:
+            type: array
+            items:
+              type: object
+              not:
+                required: ["apiGroups", "resources", "verbs"]
+                properties:
+                  apiGroups:
+                    type: array
+                    contains:
+                      type: string
+                      anyOf:
+                        - const: ""
+                        - const: '*'
+                  resources:
+                    type: array
+                    contains:
+                      type: string
+                      anyOf:
+                        - const: '*'
+                        - const: "pods/exec"
+                        - const: "pods/attach"
+                  verbs:
+                    type: array
+                    contains:
+                      type: string
+                      anyOf:
+                        - const: '*'
+                        - const: 'get'
+                        - const: 'create'
+    {{ end }}

--- a/checks/rolebindingRolePodExecAttach.yaml
+++ b/checks/rolebindingRolePodExecAttach.yaml
@@ -6,7 +6,7 @@ schemaString: |
   '$schema': http://json-schema.org/draft-07/schema
   type: object
   anyOf:
-    # Do not alert on default Roles.
+    # Do not alert on default RoleBindings.
     - required: ["metadata"]
       properties:
         metadata:
@@ -19,6 +19,18 @@ schemaString: |
                 - const: "cluster-admin"
                 - const: "system:controller:generic-garbage-collector"
                 - const: "system:controller:namespace-controller"
+    # Pass RoleBindings that point to a ClusterRole.
+    - required: ["roleRef"]
+      properties:
+        roleRef:
+          required: ["apiGroup", "kind", "name"]
+          properties:
+            apiGroup:
+              type: string
+              const: "rbac.authorization.k8s.io"
+            kind:
+              type: string
+              const: "Role"
     - required: ["roleRef"]
       properties:
         roleRef:
@@ -36,6 +48,8 @@ schemaString: |
 additionalSchemaStrings:
   rbac.authorization.k8s.io/Role: |
     type: object
+    # This schema is validated for all roleBindings, regardless of their roleRef.
+    {{ if eq .roleRef.kind "Role" }}
     # Do not alert on default RoleBindings.
     {{ if and (ne .metadata.name "cluster-admin") (ne .metadata.name "system:controller:generic-garbage-collector") (ne .metadata.name "system:controller:namespace-controller") }}
     required: ["metadata", "rules"]
@@ -79,4 +93,5 @@ additionalSchemaStrings:
                         # An exec is also possible by `get`ing a web socket.
                         - const: 'get'
                         - const: 'create'
+    {{ end }}
     {{ end }}

--- a/checks/rolebindingRolePodExecAttach.yaml
+++ b/checks/rolebindingRolePodExecAttach.yaml
@@ -6,6 +6,7 @@ schemaString: |
   '$schema': http://json-schema.org/draft-07/schema
   type: object
   anyOf:
+    # Do not alert on default Roles.
     - required: ["metadata"]
       properties:
         metadata:
@@ -35,6 +36,7 @@ schemaString: |
 additionalSchemaStrings:
   rbac.authorization.k8s.io/Role: |
     type: object
+    # Do not alert on default RoleBindings.
     {{ if and (ne .metadata.name "cluster-admin") (ne .metadata.name "system:controller:generic-garbage-collector") (ne .metadata.name "system:controller:namespace-controller") }}
     required: ["metadata", "rules"]
     allOf:
@@ -74,6 +76,7 @@ additionalSchemaStrings:
                       type: string
                       anyOf:
                         - const: '*'
+                        # An exec is also possible by `get`ing a web socket.
                         - const: 'get'
                         - const: 'create'
     {{ end }}

--- a/checks/rolebindingRolePodExecAttach.yaml
+++ b/checks/rolebindingRolePodExecAttach.yaml
@@ -6,19 +6,6 @@ schemaString: |
   '$schema': http://json-schema.org/draft-07/schema
   type: object
   anyOf:
-    # Do not alert on default RoleBindings.
-    - required: ["metadata"]
-      properties:
-        metadata:
-          type: object
-          required: ["name"]
-          properties:
-            name:
-              type: string
-              anyOf:
-                - const: "cluster-admin"
-                - const: "system:controller:generic-garbage-collector"
-                - const: "system:controller:namespace-controller"
     # Pass RoleBindings that point to a ClusterRole.
     - required: ["roleRef"]
       properties:
@@ -50,8 +37,6 @@ additionalSchemaStrings:
     type: object
     # This schema is validated for all roleBindings, regardless of their roleRef.
     {{ if eq .roleRef.kind "Role" }}
-    # Do not alert on default RoleBindings.
-    {{ if and (ne .metadata.name "cluster-admin") (ne .metadata.name "system:controller:generic-garbage-collector") (ne .metadata.name "system:controller:namespace-controller") }}
     required: ["metadata", "rules"]
     allOf:
       - properties:
@@ -93,5 +78,4 @@ additionalSchemaStrings:
                         # An exec is also possible by `get`ing a web socket.
                         - const: 'get'
                         - const: 'create'
-    {{ end }}
     {{ end }}

--- a/checks/rolebindingRolePodExecAttach.yaml
+++ b/checks/rolebindingRolePodExecAttach.yaml
@@ -1,0 +1,79 @@
+successMessage: The RoleBinding does not reference a Role allowing Pod exec or attach
+failureMessage: The RoleBinding references a Role that allows Pods/exec or pods/attach
+category: Security
+target: rbac.authorization.k8s.io/RoleBinding
+schemaString: |
+  '$schema': http://json-schema.org/draft-07/schema
+  type: object
+  anyOf:
+    - required: ["metadata"]
+      properties:
+        metadata:
+          type: object
+          required: ["name"]
+          properties:
+            name:
+              type: string
+              anyOf:
+                - const: "cluster-admin"
+                - const: "system:controller:generic-garbage-collector"
+                - const: "system:controller:namespace-controller"
+    - required: ["roleRef"]
+      properties:
+        roleRef:
+          required: ["apiGroup", "kind", "name"]
+          properties:
+            apiGroup:
+              type: string
+              const: "rbac.authorization.k8s.io"
+            kind:
+              type: string
+              const: "Role"
+            name:
+              type: string
+              minLength: 1
+additionalSchemaStrings:
+  rbac.authorization.k8s.io/Role: |
+    type: object
+    {{ if and (ne .metadata.name "cluster-admin") (ne .metadata.name "system:controller:generic-garbage-collector") (ne .metadata.name "system:controller:namespace-controller") }}
+    required: ["metadata", "rules"]
+    allOf:
+      - properties:
+          metadata:
+            required: ["name"]
+            properties:
+              name:
+                type: string
+                const: "{{ .roleRef.name }}"
+      - properties:
+          rules:
+            type: array
+            items:
+              type: object
+              not:
+                required: ["apiGroups", "resources", "verbs"]
+                properties:
+                  apiGroups:
+                    type: array
+                    contains:
+                      type: string
+                      anyOf:
+                        - const: ""
+                        - const: '*'
+                  resources:
+                    type: array
+                    contains:
+                      type: string
+                      anyOf:
+                        - const: '*'
+                        - const: "pods/exec"
+                        - const: "pods/attach"
+                  verbs:
+                    type: array
+                    contains:
+                      type: string
+                      anyOf:
+                        - const: '*'
+                        - const: 'get'
+                        - const: 'create'
+    {{ end }}

--- a/checks/rolebindingRolePodExecAttach.yaml
+++ b/checks/rolebindingRolePodExecAttach.yaml
@@ -1,5 +1,5 @@
 successMessage: The RoleBinding does not reference a Role allowing Pod exec or attach
-failureMessage: The RoleBinding references a Role that allows Pods/exec or pods/attach
+failureMessage: The RoleBinding references a Role that allows Pods/exec, allows pods/attach, or that does not exist
 category: Security
 target: rbac.authorization.k8s.io/RoleBinding
 schemaString: |

--- a/examples/config-full.yaml
+++ b/examples/config-full.yaml
@@ -27,6 +27,11 @@ checks:
   hostPortSet: warning
   sensitiveContainerEnvVar: danger
   sensitiveConfigmapContent: danger
+  clusterrolePodExecAttach: danger
+  rolePodExecAttach: danger
+  clusterrolebindingPodExecAttach: danger
+  rolebindingClusterRolePodExecAttach: danger
+  rolebindingRolePodExecAttach: danger
   # custom
   resourceLimits: warning
   imageRegistry: danger

--- a/pkg/config/checks.go
+++ b/pkg/config/checks.go
@@ -59,8 +59,11 @@ var (
 		"missingPodDisruptionBudget",
 		"missingNetworkPolicy",
 		"sensitiveConfigmapContent",
-		"rolePodExecAttach",
 		"clusterrolePodExecAttach",
+		"rolePodExecAttach",
+		"clusterrolebindingPodExecAttach",
+		"rolebindingClusterRolePodExecAttach",
+		"rolebindingRolePodExecAttach",
 	}
 )
 

--- a/pkg/config/checks.go
+++ b/pkg/config/checks.go
@@ -59,6 +59,8 @@ var (
 		"missingPodDisruptionBudget",
 		"missingNetworkPolicy",
 		"sensitiveConfigmapContent",
+		"rolePodExecAttach",
+		"clusterrolePodExecAttach",
 	}
 )
 

--- a/test/checks/clusterrolePodExecAttach/failure.all_wildcards.yaml
+++ b/test/checks/clusterrolePodExecAttach/failure.all_wildcards.yaml
@@ -1,0 +1,9 @@
+# This fails because the ClusterRole apiGroups, resources, and verbs are all * which allows pods/exec|attach.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "*" ]
+    verbs: [ "*" ]

--- a/test/checks/clusterrolePodExecAttach/failure.attach_explicit.yaml
+++ b/test/checks/clusterrolePodExecAttach/failure.attach_explicit.yaml
@@ -1,0 +1,9 @@
+# This fails because the ClusterRole allows pods/attach.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/attach" ]
+    verbs: [ create ]

--- a/test/checks/clusterrolePodExecAttach/failure.attach_using_verb_wildcard.yaml
+++ b/test/checks/clusterrolePodExecAttach/failure.attach_using_verb_wildcard.yaml
@@ -1,0 +1,9 @@
+# This fails because the ClusterRole allows pods/attach using all verbs.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/attach" ]
+    verbs: [ "*" ]

--- a/test/checks/clusterrolePodExecAttach/failure.create_attach_and_exec_using_resource_wildcard.yaml
+++ b/test/checks/clusterrolePodExecAttach/failure.create_attach_and_exec_using_resource_wildcard.yaml
@@ -1,0 +1,9 @@
+# This fails because the ClusterRole allows pods/attach|exec using all resources.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "*" ]
+    verbs: [ create ]

--- a/test/checks/clusterrolePodExecAttach/failure.create_attach_using_apigroup_wildcard.yaml
+++ b/test/checks/clusterrolePodExecAttach/failure.create_attach_using_apigroup_wildcard.yaml
@@ -1,0 +1,9 @@
+# This fails because the ClusterRole allows pods/attach using all apiGroups.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "pods/attach" ]
+    verbs: [ create ]

--- a/test/checks/clusterrolePodExecAttach/failure.create_exec_using_apigroup_wildcard.yaml
+++ b/test/checks/clusterrolePodExecAttach/failure.create_exec_using_apigroup_wildcard.yaml
@@ -1,0 +1,9 @@
+# This fails because the ClusterRole allows pods/exec using all apiGroups.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "pods/exec" ]
+    verbs: [ create ]

--- a/test/checks/clusterrolePodExecAttach/failure.exec_explicit.yaml
+++ b/test/checks/clusterrolePodExecAttach/failure.exec_explicit.yaml
@@ -1,0 +1,9 @@
+# This fails because the ClusterRole allows pods/exec.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/exec" ]
+    verbs: [ create ]

--- a/test/checks/clusterrolePodExecAttach/failure.exec_verb_wildcard.yaml
+++ b/test/checks/clusterrolePodExecAttach/failure.exec_verb_wildcard.yaml
@@ -1,0 +1,9 @@
+# This fails because the ClusterRole allows pods/exec using all verbs.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/exec" ]
+    verbs: [ "*" ]

--- a/test/checks/clusterrolePodExecAttach/failure.get_attach_and_exec_using_resource_wildcard.yaml
+++ b/test/checks/clusterrolePodExecAttach/failure.get_attach_and_exec_using_resource_wildcard.yaml
@@ -1,0 +1,9 @@
+# This fails because the ClusterRole allows pods/attach|exec using all resources.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "*" ]
+    verbs: [ get ]

--- a/test/checks/clusterrolePodExecAttach/failure.get_attach_using_apigroup_wildcard.yaml
+++ b/test/checks/clusterrolePodExecAttach/failure.get_attach_using_apigroup_wildcard.yaml
@@ -1,0 +1,9 @@
+# This fails because the ClusterRole allows pods/attach using all apiGroups.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "pods/attach" ]
+    verbs: [ get ]

--- a/test/checks/clusterrolePodExecAttach/failure.get_exec_using_apigroup_wildcard.yaml
+++ b/test/checks/clusterrolePodExecAttach/failure.get_exec_using_apigroup_wildcard.yaml
@@ -1,0 +1,9 @@
+# This fails because the ClusterRole allows pods/exec using all apiGroups.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "pods/exec" ]
+    verbs: [ get ]

--- a/test/checks/clusterrolePodExecAttach/success.allow_unrelated_perms.yaml
+++ b/test/checks/clusterrolePodExecAttach/success.allow_unrelated_perms.yaml
@@ -1,0 +1,9 @@
+# This succeeds because the ClusterRole does not allow pods/exec|attach.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods" ]
+    verbs: [ get, create ]

--- a/test/checks/clusterrolePodExecAttach/success.attach_wrong_verb.yaml
+++ b/test/checks/clusterrolePodExecAttach/success.attach_wrong_verb.yaml
@@ -1,0 +1,9 @@
+# This succeeds because the ClusterRole allows pods/attach but with a safe verb.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/attach" ]
+    verbs: [ list ]

--- a/test/checks/clusterrolePodExecAttach/success.defaultclusterrole_admin.yaml
+++ b/test/checks/clusterrolePodExecAttach/success.defaultclusterrole_admin.yaml
@@ -1,0 +1,9 @@
+# This succeeds because the ClusterRole is an expected default one (by name).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: admin
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/attach" ]
+    verbs: [ "create" ]

--- a/test/checks/clusterrolePodExecAttach/success.defaultclusterrole_clusteradmin.yaml
+++ b/test/checks/clusterrolePodExecAttach/success.defaultclusterrole_clusteradmin.yaml
@@ -1,0 +1,9 @@
+# This succeeds because the ClusterRole is an expected default one (by name).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-admin
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/exec" ]
+    verbs: [ "create" ]

--- a/test/checks/clusterrolePodExecAttach/success.exec_wrong_verb.yaml
+++ b/test/checks/clusterrolePodExecAttach/success.exec_wrong_verb.yaml
@@ -1,0 +1,9 @@
+# This succeeds because the ClusterRole allows pods/exec but with a safe verb.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/exec" ]
+    verbs: [ list ]

--- a/test/checks/clusterrolebindingPodExecAttach/failure.all_wildcards.yaml
+++ b/test/checks/clusterrolebindingPodExecAttach/failure.all_wildcards.yaml
@@ -1,0 +1,22 @@
+# This fails because the ClusterRole apiGroups, resources, and verbs are all * which allows pods/exec|attach.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "*" ]
+    verbs: [ "*" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/clusterrolebindingPodExecAttach/failure.attach_explicit.yaml
+++ b/test/checks/clusterrolebindingPodExecAttach/failure.attach_explicit.yaml
@@ -1,0 +1,22 @@
+# This fails because the ClusterRole allows pods/attach.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/attach" ]
+    verbs: [ create ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/clusterrolebindingPodExecAttach/failure.attach_using_verb_wildcard.yaml
+++ b/test/checks/clusterrolebindingPodExecAttach/failure.attach_using_verb_wildcard.yaml
@@ -1,0 +1,22 @@
+# This fails because the ClusterRole allows pods/attach using all verbs.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/attach" ]
+    verbs: [ "*" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/clusterrolebindingPodExecAttach/failure.binding_points_to_missing_ref.yaml
+++ b/test/checks/clusterrolebindingPodExecAttach/failure.binding_points_to_missing_ref.yaml
@@ -1,0 +1,13 @@
+# This fails because the roleRef points to a ClusterRole that does not exist.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: does-not-exist
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/clusterrolebindingPodExecAttach/failure.create_attach_and_exec_using_resource_wildcard.yaml
+++ b/test/checks/clusterrolebindingPodExecAttach/failure.create_attach_and_exec_using_resource_wildcard.yaml
@@ -1,0 +1,22 @@
+# This fails because the ClusterRole allows pods/attach|exec using all resources.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "*" ]
+    verbs: [ create ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/clusterrolebindingPodExecAttach/failure.create_attach_using_apigroup_wildcard.yaml
+++ b/test/checks/clusterrolebindingPodExecAttach/failure.create_attach_using_apigroup_wildcard.yaml
@@ -1,0 +1,22 @@
+# This fails because the ClusterRole allows pods/attach using all apiGroups.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "pods/attach" ]
+    verbs: [ create ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/clusterrolebindingPodExecAttach/failure.create_exec_using_apigroup_wildcard.yaml
+++ b/test/checks/clusterrolebindingPodExecAttach/failure.create_exec_using_apigroup_wildcard.yaml
@@ -1,0 +1,22 @@
+# This fails because the ClusterRole allows pods/exec using all apiGroups.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "pods/exec" ]
+    verbs: [ create ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/clusterrolebindingPodExecAttach/failure.exec_explicit.yaml
+++ b/test/checks/clusterrolebindingPodExecAttach/failure.exec_explicit.yaml
@@ -1,0 +1,22 @@
+# This fails because the ClusterRole allows pods/exec.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/exec" ]
+    verbs: [ create ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/clusterrolebindingPodExecAttach/failure.exec_verb_wildcard.yaml
+++ b/test/checks/clusterrolebindingPodExecAttach/failure.exec_verb_wildcard.yaml
@@ -1,0 +1,22 @@
+# This fails because the ClusterRole allows pods/exec using all verbs.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/exec" ]
+    verbs: [ "*" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/clusterrolebindingPodExecAttach/failure.get_attach_and_exec_using_resource_wildcard.yaml
+++ b/test/checks/clusterrolebindingPodExecAttach/failure.get_attach_and_exec_using_resource_wildcard.yaml
@@ -1,0 +1,22 @@
+# This fails because the ClusterRole allows pods/attach|exec using all resources.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "*" ]
+    verbs: [ get ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/clusterrolebindingPodExecAttach/failure.get_attach_using_apigroup_wildcard.yaml
+++ b/test/checks/clusterrolebindingPodExecAttach/failure.get_attach_using_apigroup_wildcard.yaml
@@ -1,0 +1,22 @@
+# This fails because the ClusterRole allows pods/attach using all apiGroups.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "pods/attach" ]
+    verbs: [ get ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/clusterrolebindingPodExecAttach/failure.get_exec_using_apigroup_wildcard.yaml
+++ b/test/checks/clusterrolebindingPodExecAttach/failure.get_exec_using_apigroup_wildcard.yaml
@@ -1,0 +1,22 @@
+# This fails because the ClusterRole allows pods/exec using all apiGroups.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "pods/exec" ]
+    verbs: [ get ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/clusterrolebindingPodExecAttach/success.allow_unrelated_perms.yaml
+++ b/test/checks/clusterrolebindingPodExecAttach/success.allow_unrelated_perms.yaml
@@ -1,0 +1,22 @@
+# This succeeds because the ClusterRole does not allow pods/exec|attach.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods" ]
+    verbs: [ get, create ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/clusterrolebindingPodExecAttach/success.attach_wrong_verb.yaml
+++ b/test/checks/clusterrolebindingPodExecAttach/success.attach_wrong_verb.yaml
@@ -1,0 +1,22 @@
+# This succeeds because the ClusterRole allows pods/attach but with a safe verb.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/attach" ]
+    verbs: [ list ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/clusterrolebindingPodExecAttach/success.defaultclusterrolebinding_clusteradmin.yaml
+++ b/test/checks/clusterrolebindingPodExecAttach/success.defaultclusterrolebinding_clusteradmin.yaml
@@ -1,0 +1,34 @@
+# This succeeds because the ClusterRoleBinding is a default one (by name).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser
+---
+# This ClusterRole satisfies the above binding.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-admin
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/exec" ]
+    verbs: [ "create" ]
+---
+  # This Role exists so there is at least one Role for the additionalSchema to find.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: not-used
+  namespace: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods" ]
+    verbs: [ "get" ]

--- a/test/checks/clusterrolebindingPodExecAttach/success.defaultclusterrolebinding_system-controller-generic-garbage-collector.yaml
+++ b/test/checks/clusterrolebindingPodExecAttach/success.defaultclusterrolebinding_system-controller-generic-garbage-collector.yaml
@@ -1,0 +1,34 @@
+# This succeeds because the ClusterRoleBinding is a default one (by name).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:controller:generic-garbage-collector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:controller:generic-garbage-collector
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser
+---
+# This ClusterRole satisfies the above binding.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:controller:generic-garbage-collector
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/attach" ]
+    verbs: [ "create" ]
+---
+  # This Role exists so there is at least one Role for the additionalSchema to find.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: not-used
+  namespace: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods" ]
+    verbs: [ "get" ]

--- a/test/checks/clusterrolebindingPodExecAttach/success.exec_wrong_verb.yaml
+++ b/test/checks/clusterrolebindingPodExecAttach/success.exec_wrong_verb.yaml
@@ -1,0 +1,22 @@
+# This succeeds because the ClusterRole allows pods/exec but with a safe verb.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/exec" ]
+    verbs: [ list ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolePodExecAttach/failure.all_wildcards.yaml
+++ b/test/checks/rolePodExecAttach/failure.all_wildcards.yaml
@@ -1,0 +1,10 @@
+# This fails because the Role apiGroups, resources, and verbs are all * which allows pods/exec|attach.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+  namespace: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "*" ]
+    verbs: [ "*" ]

--- a/test/checks/rolePodExecAttach/failure.attach_explicit.yaml
+++ b/test/checks/rolePodExecAttach/failure.attach_explicit.yaml
@@ -1,0 +1,10 @@
+# This fails because the Role allows pods/attach.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+  namespace: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/attach" ]
+    verbs: [ create ]

--- a/test/checks/rolePodExecAttach/failure.attach_using_verb_wildcard.yaml
+++ b/test/checks/rolePodExecAttach/failure.attach_using_verb_wildcard.yaml
@@ -1,0 +1,10 @@
+# This fails because the Role allows pods/attach using all verbs.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+  namespace: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/attach" ]
+    verbs: [ "*" ]

--- a/test/checks/rolePodExecAttach/failure.create_attach_and_exec_using_resource_wildcard.yaml
+++ b/test/checks/rolePodExecAttach/failure.create_attach_and_exec_using_resource_wildcard.yaml
@@ -1,0 +1,10 @@
+# This fails because the Role allows pods/attach|exec using all resources.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+  namespace: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "*" ]
+    verbs: [ create ]

--- a/test/checks/rolePodExecAttach/failure.create_attach_using_apigroup_wildcard.yaml
+++ b/test/checks/rolePodExecAttach/failure.create_attach_using_apigroup_wildcard.yaml
@@ -1,0 +1,10 @@
+# This fails because the Role allows pods/attach using all apiGroups.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+  namespace: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "pods/attach" ]
+    verbs: [ create ]

--- a/test/checks/rolePodExecAttach/failure.create_exec_using_apigroup_wildcard.yaml
+++ b/test/checks/rolePodExecAttach/failure.create_exec_using_apigroup_wildcard.yaml
@@ -1,0 +1,10 @@
+# This fails because the Role allows pods/exec using all apiGroups.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+  namespace: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "pods/exec" ]
+    verbs: [ create ]

--- a/test/checks/rolePodExecAttach/failure.exec_explicit.yaml
+++ b/test/checks/rolePodExecAttach/failure.exec_explicit.yaml
@@ -1,0 +1,10 @@
+# This fails because the Role allows pods/exec.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+  namespace: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/exec" ]
+    verbs: [ create ]

--- a/test/checks/rolePodExecAttach/failure.exec_verb_wildcard.yaml
+++ b/test/checks/rolePodExecAttach/failure.exec_verb_wildcard.yaml
@@ -1,0 +1,10 @@
+# This fails because the Role allows pods/exec using all verbs.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+  namespace: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/exec" ]
+    verbs: [ "*" ]

--- a/test/checks/rolePodExecAttach/failure.get_attach_and_exec_using_resource_wildcard.yaml
+++ b/test/checks/rolePodExecAttach/failure.get_attach_and_exec_using_resource_wildcard.yaml
@@ -1,0 +1,10 @@
+# This fails because the Role allows pods/attach|exec using all resources.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+  namespace: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "*" ]
+    verbs: [ get ]

--- a/test/checks/rolePodExecAttach/failure.get_attach_using_apigroup_wildcard.yaml
+++ b/test/checks/rolePodExecAttach/failure.get_attach_using_apigroup_wildcard.yaml
@@ -1,0 +1,10 @@
+# This fails because the Role allows pods/attach using all apiGroups.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+  namespace: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "pods/attach" ]
+    verbs: [ get ]

--- a/test/checks/rolePodExecAttach/failure.get_exec_using_apigroup_wildcard.yaml
+++ b/test/checks/rolePodExecAttach/failure.get_exec_using_apigroup_wildcard.yaml
@@ -1,0 +1,10 @@
+# This fails because the Role allows pods/exec using all apiGroups.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+  namespace: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "pods/exec" ]
+    verbs: [ get ]

--- a/test/checks/rolePodExecAttach/success.allow_unrelated_perms.yaml
+++ b/test/checks/rolePodExecAttach/success.allow_unrelated_perms.yaml
@@ -1,0 +1,10 @@
+# This succeeds because the Role does not allow pods/exec|attach.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+  namespace: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods" ]
+    verbs: [ get, create ]

--- a/test/checks/rolePodExecAttach/success.attach_wrong_verb.yaml
+++ b/test/checks/rolePodExecAttach/success.attach_wrong_verb.yaml
@@ -1,0 +1,9 @@
+# This succeeds because the Role allows pods/attach but with a safe verb.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/attach" ]
+    verbs: [ list ]

--- a/test/checks/rolePodExecAttach/success.exec_wrong_verb.yaml
+++ b/test/checks/rolePodExecAttach/success.exec_wrong_verb.yaml
@@ -1,0 +1,9 @@
+# This succeeds because the Role allows pods/exec but with a safe verb.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/exec" ]
+    verbs: [ list ]

--- a/test/checks/rolebindingClusterRolePodExecAttach/failure.all_wildcards.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/failure.all_wildcards.yaml
@@ -1,0 +1,22 @@
+# This fails because the ClusterRole apiGroups, resources, and verbs are all * which allows pods/exec|attach.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "*" ]
+    verbs: [ "*" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingClusterRolePodExecAttach/failure.all_wildcards.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/failure.all_wildcards.yaml
@@ -12,6 +12,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/test/checks/rolebindingClusterRolePodExecAttach/failure.attach_explicit.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/failure.attach_explicit.yaml
@@ -12,6 +12,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/test/checks/rolebindingClusterRolePodExecAttach/failure.attach_explicit.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/failure.attach_explicit.yaml
@@ -1,0 +1,22 @@
+# This fails because the ClusterRole allows pods/attach.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/attach" ]
+    verbs: [ create ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingClusterRolePodExecAttach/failure.attach_using_verb_wildcard.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/failure.attach_using_verb_wildcard.yaml
@@ -12,6 +12,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/test/checks/rolebindingClusterRolePodExecAttach/failure.attach_using_verb_wildcard.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/failure.attach_using_verb_wildcard.yaml
@@ -1,0 +1,22 @@
+# This fails because the ClusterRole allows pods/attach using all verbs.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/attach" ]
+    verbs: [ "*" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingClusterRolePodExecAttach/failure.binding_points_to_missing_ref.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/failure.binding_points_to_missing_ref.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/test/checks/rolebindingClusterRolePodExecAttach/failure.binding_points_to_missing_ref.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/failure.binding_points_to_missing_ref.yaml
@@ -1,0 +1,13 @@
+# This fails because the roleRef points to a ClusterRole that does not exist.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: does-not-exist
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingClusterRolePodExecAttach/failure.create_attach_and_exec_using_resource_wildcard.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/failure.create_attach_and_exec_using_resource_wildcard.yaml
@@ -12,6 +12,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/test/checks/rolebindingClusterRolePodExecAttach/failure.create_attach_and_exec_using_resource_wildcard.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/failure.create_attach_and_exec_using_resource_wildcard.yaml
@@ -1,0 +1,22 @@
+# This fails because the ClusterRole allows pods/attach|exec using all resources.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "*" ]
+    verbs: [ create ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingClusterRolePodExecAttach/failure.create_attach_using_apigroup_wildcard.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/failure.create_attach_using_apigroup_wildcard.yaml
@@ -12,6 +12,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/test/checks/rolebindingClusterRolePodExecAttach/failure.create_attach_using_apigroup_wildcard.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/failure.create_attach_using_apigroup_wildcard.yaml
@@ -1,0 +1,22 @@
+# This fails because the ClusterRole allows pods/attach using all apiGroups.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "pods/attach" ]
+    verbs: [ create ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingClusterRolePodExecAttach/failure.create_exec_using_apigroup_wildcard.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/failure.create_exec_using_apigroup_wildcard.yaml
@@ -12,6 +12,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/test/checks/rolebindingClusterRolePodExecAttach/failure.create_exec_using_apigroup_wildcard.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/failure.create_exec_using_apigroup_wildcard.yaml
@@ -1,0 +1,22 @@
+# This fails because the ClusterRole allows pods/exec using all apiGroups.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "pods/exec" ]
+    verbs: [ create ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingClusterRolePodExecAttach/failure.exec_explicit.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/failure.exec_explicit.yaml
@@ -12,6 +12,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/test/checks/rolebindingClusterRolePodExecAttach/failure.exec_explicit.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/failure.exec_explicit.yaml
@@ -1,0 +1,22 @@
+# This fails because the ClusterRole allows pods/exec.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/exec" ]
+    verbs: [ create ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingClusterRolePodExecAttach/failure.exec_verb_wildcard.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/failure.exec_verb_wildcard.yaml
@@ -12,6 +12,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/test/checks/rolebindingClusterRolePodExecAttach/failure.exec_verb_wildcard.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/failure.exec_verb_wildcard.yaml
@@ -1,0 +1,22 @@
+# This fails because the ClusterRole allows pods/exec using all verbs.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/exec" ]
+    verbs: [ "*" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingClusterRolePodExecAttach/failure.get_attach_and_exec_using_resource_wildcard.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/failure.get_attach_and_exec_using_resource_wildcard.yaml
@@ -12,6 +12,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/test/checks/rolebindingClusterRolePodExecAttach/failure.get_attach_and_exec_using_resource_wildcard.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/failure.get_attach_and_exec_using_resource_wildcard.yaml
@@ -1,0 +1,22 @@
+# This fails because the ClusterRole allows pods/attach|exec using all resources.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "*" ]
+    verbs: [ get ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingClusterRolePodExecAttach/failure.get_attach_using_apigroup_wildcard.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/failure.get_attach_using_apigroup_wildcard.yaml
@@ -1,0 +1,22 @@
+# This fails because the ClusterRole allows pods/attach using all apiGroups.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "pods/attach" ]
+    verbs: [ get ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingClusterRolePodExecAttach/failure.get_attach_using_apigroup_wildcard.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/failure.get_attach_using_apigroup_wildcard.yaml
@@ -12,6 +12,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/test/checks/rolebindingClusterRolePodExecAttach/failure.get_exec_using_apigroup_wildcard.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/failure.get_exec_using_apigroup_wildcard.yaml
@@ -12,6 +12,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/test/checks/rolebindingClusterRolePodExecAttach/failure.get_exec_using_apigroup_wildcard.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/failure.get_exec_using_apigroup_wildcard.yaml
@@ -1,0 +1,22 @@
+# This fails because the ClusterRole allows pods/exec using all apiGroups.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "pods/exec" ]
+    verbs: [ get ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingClusterRolePodExecAttach/success.allow_unrelated_perms.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/success.allow_unrelated_perms.yaml
@@ -1,0 +1,22 @@
+# This succeeds because the ClusterRole does not allow pods/exec|attach.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods" ]
+    verbs: [ get, create ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingClusterRolePodExecAttach/success.attach_wrong_verb.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/success.attach_wrong_verb.yaml
@@ -12,6 +12,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/test/checks/rolebindingClusterRolePodExecAttach/success.attach_wrong_verb.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/success.attach_wrong_verb.yaml
@@ -1,0 +1,22 @@
+# This succeeds because the ClusterRole allows pods/attach but with a safe verb.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/attach" ]
+    verbs: [ list ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingClusterRolePodExecAttach/success.binding_references_role.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/success.binding_references_role.yaml
@@ -1,8 +1,19 @@
-# This succeeds because the ClusterRole does not allow pods/exec|attach.
+# This succeeds because the roleBinding references a Role instead of a ClusterRole.
+# THis ClusterRole exists so there is at leat one ClusterRole for the additionalSchema to find.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: not-used
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods" ]
+    verbs: [ list ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   name: test
+  namespace: test
 rules:
   - apiGroups: [ "" ]
     resources: [ "pods" ]
@@ -15,7 +26,7 @@ metadata:
   namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: test
 subjects:
 - apiGroup: rbac.authorization.k8s.io

--- a/test/checks/rolebindingClusterRolePodExecAttach/success.exec_wrong_verb.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/success.exec_wrong_verb.yaml
@@ -12,6 +12,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/test/checks/rolebindingClusterRolePodExecAttach/success.exec_wrong_verb.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/success.exec_wrong_verb.yaml
@@ -1,0 +1,22 @@
+# This succeeds because the ClusterRole allows pods/exec but with a safe verb.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/exec" ]
+    verbs: [ list ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingRolePodExecAttach/failure.all_wildcards.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/failure.all_wildcards.yaml
@@ -1,0 +1,22 @@
+# This fails because the Role apiGroups, resources, and verbs are all * which allows pods/exec|attach.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "*" ]
+    verbs: [ "*" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingRolePodExecAttach/failure.all_wildcards.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/failure.all_wildcards.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: test
+  namespace: test
 rules:
   - apiGroups: [ "*" ]
     resources: [ "*" ]
@@ -12,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/test/checks/rolebindingRolePodExecAttach/failure.attach_explicit.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/failure.attach_explicit.yaml
@@ -1,0 +1,22 @@
+# This fails because the Role allows pods/attach.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/attach" ]
+    verbs: [ create ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingRolePodExecAttach/failure.attach_explicit.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/failure.attach_explicit.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: test
+  namespace: test
 rules:
   - apiGroups: [ "" ]
     resources: [ "pods/attach" ]
@@ -12,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/test/checks/rolebindingRolePodExecAttach/failure.attach_using_verb_wildcard.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/failure.attach_using_verb_wildcard.yaml
@@ -1,0 +1,22 @@
+# This fails because the Role allows pods/attach using all verbs.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/attach" ]
+    verbs: [ "*" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingRolePodExecAttach/failure.attach_using_verb_wildcard.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/failure.attach_using_verb_wildcard.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: test
+  namespace: test
 rules:
   - apiGroups: [ "" ]
     resources: [ "pods/attach" ]
@@ -12,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/test/checks/rolebindingRolePodExecAttach/failure.binding_points_to_missing_ref.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/failure.binding_points_to_missing_ref.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/test/checks/rolebindingRolePodExecAttach/failure.binding_points_to_missing_ref.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/failure.binding_points_to_missing_ref.yaml
@@ -1,0 +1,13 @@
+# This fails because the roleRef points to a Role that does not exist.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: does-not-exist
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingRolePodExecAttach/failure.create_attach_and_exec_using_resource_wildcard.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/failure.create_attach_and_exec_using_resource_wildcard.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: test
+  namespace: test
 rules:
   - apiGroups: [ "" ]
     resources: [ "*" ]
@@ -12,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/test/checks/rolebindingRolePodExecAttach/failure.create_attach_and_exec_using_resource_wildcard.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/failure.create_attach_and_exec_using_resource_wildcard.yaml
@@ -1,0 +1,22 @@
+# This fails because the Role allows pods/attach|exec using all resources.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "*" ]
+    verbs: [ create ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingRolePodExecAttach/failure.create_attach_using_apigroup_wildcard.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/failure.create_attach_using_apigroup_wildcard.yaml
@@ -1,0 +1,22 @@
+# This fails because the Role allows pods/attach using all apiGroups.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "pods/attach" ]
+    verbs: [ create ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingRolePodExecAttach/failure.create_attach_using_apigroup_wildcard.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/failure.create_attach_using_apigroup_wildcard.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: test
+  namespace: test
 rules:
   - apiGroups: [ "*" ]
     resources: [ "pods/attach" ]
@@ -12,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/test/checks/rolebindingRolePodExecAttach/failure.create_exec_using_apigroup_wildcard.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/failure.create_exec_using_apigroup_wildcard.yaml
@@ -1,0 +1,22 @@
+# This fails because the Role allows pods/exec using all apiGroups.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "pods/exec" ]
+    verbs: [ create ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingRolePodExecAttach/failure.create_exec_using_apigroup_wildcard.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/failure.create_exec_using_apigroup_wildcard.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: test
+  namespace: test
 rules:
   - apiGroups: [ "*" ]
     resources: [ "pods/exec" ]
@@ -12,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/test/checks/rolebindingRolePodExecAttach/failure.exec_explicit.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/failure.exec_explicit.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: test
+  namespace: test
 rules:
   - apiGroups: [ "" ]
     resources: [ "pods/exec" ]
@@ -12,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/test/checks/rolebindingRolePodExecAttach/failure.exec_explicit.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/failure.exec_explicit.yaml
@@ -1,0 +1,22 @@
+# This fails because the Role allows pods/exec.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/exec" ]
+    verbs: [ create ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingRolePodExecAttach/failure.exec_verb_wildcard.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/failure.exec_verb_wildcard.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: test
+  namespace: test
 rules:
   - apiGroups: [ "" ]
     resources: [ "pods/exec" ]
@@ -12,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/test/checks/rolebindingRolePodExecAttach/failure.exec_verb_wildcard.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/failure.exec_verb_wildcard.yaml
@@ -1,0 +1,22 @@
+# This fails because the Role allows pods/exec using all verbs.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/exec" ]
+    verbs: [ "*" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingRolePodExecAttach/failure.get_attach_and_exec_using_resource_wildcard.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/failure.get_attach_and_exec_using_resource_wildcard.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: test
+  namespace: test
 rules:
   - apiGroups: [ "" ]
     resources: [ "*" ]
@@ -12,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/test/checks/rolebindingRolePodExecAttach/failure.get_attach_and_exec_using_resource_wildcard.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/failure.get_attach_and_exec_using_resource_wildcard.yaml
@@ -1,0 +1,22 @@
+# This fails because the Role allows pods/attach|exec using all resources.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "*" ]
+    verbs: [ get ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingRolePodExecAttach/failure.get_attach_using_apigroup_wildcard.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/failure.get_attach_using_apigroup_wildcard.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: test
+  namespace: test
 rules:
   - apiGroups: [ "*" ]
     resources: [ "pods/attach" ]
@@ -12,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/test/checks/rolebindingRolePodExecAttach/failure.get_attach_using_apigroup_wildcard.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/failure.get_attach_using_apigroup_wildcard.yaml
@@ -1,0 +1,22 @@
+# This fails because the Role allows pods/attach using all apiGroups.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "pods/attach" ]
+    verbs: [ get ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingRolePodExecAttach/failure.get_exec_using_apigroup_wildcard.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/failure.get_exec_using_apigroup_wildcard.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: test
+  namespace: test
 rules:
   - apiGroups: [ "*" ]
     resources: [ "pods/exec" ]
@@ -12,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/test/checks/rolebindingRolePodExecAttach/failure.get_exec_using_apigroup_wildcard.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/failure.get_exec_using_apigroup_wildcard.yaml
@@ -1,0 +1,22 @@
+# This fails because the Role allows pods/exec using all apiGroups.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "pods/exec" ]
+    verbs: [ get ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingRolePodExecAttach/success.allow_unrelated_perms.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/success.allow_unrelated_perms.yaml
@@ -1,0 +1,22 @@
+# This succeeds because the Role does not allow pods/exec|attach.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods" ]
+    verbs: [ get, create ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingRolePodExecAttach/success.allow_unrelated_perms.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/success.allow_unrelated_perms.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: test
+  namespace: test
 rules:
   - apiGroups: [ "" ]
     resources: [ "pods" ]
@@ -12,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/test/checks/rolebindingRolePodExecAttach/success.attach_wrong_verb.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/success.attach_wrong_verb.yaml
@@ -1,0 +1,22 @@
+# This succeeds because the Role allows pods/attach but with a safe verb.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/attach" ]
+    verbs: [ list ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingRolePodExecAttach/success.attach_wrong_verb.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/success.attach_wrong_verb.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: test
+  namespace: test
 rules:
   - apiGroups: [ "" ]
     resources: [ "pods/attach" ]
@@ -12,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/test/checks/rolebindingRolePodExecAttach/success.binding_references_role.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/success.binding_references_role.yaml
@@ -1,8 +1,19 @@
-# This succeeds because the ClusterRole does not allow pods/exec|attach.
+# This succeeds because the roleBinding references a Role instead of a ClusterRole.
+# THis ClusterRole exists so there is at leat one ClusterRole for the additionalSchema to find.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: not-used
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods" ]
+    verbs: [ list ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   name: test
+  namespace: test
 rules:
   - apiGroups: [ "" ]
     resources: [ "pods" ]
@@ -15,7 +26,7 @@ metadata:
   namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: test
 subjects:
 - apiGroup: rbac.authorization.k8s.io

--- a/test/checks/rolebindingRolePodExecAttach/success.exec_wrong_verb.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/success.exec_wrong_verb.yaml
@@ -1,0 +1,22 @@
+# This succeeds because the Role allows pods/exec but with a safe verb.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods/exec" ]
+    verbs: [ list ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser

--- a/test/checks/rolebindingRolePodExecAttach/success.exec_wrong_verb.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/success.exec_wrong_verb.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: test
+  namespace: test
 rules:
   - apiGroups: [ "" ]
     resources: [ "pods/exec" ]
@@ -12,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: test
+  namespace: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/test/fixtures.go
+++ b/test/fixtures.go
@@ -259,6 +259,7 @@ func SetupTestAPI(objects ...runtime.Object) (kubernetes.Interface, dynamic.Inte
 		{
 			GroupVersion: "rbac.authorization.k8s.io/v1",
 			APIResources: []metav1.APIResource{
+				{Name: "clusterroles", Namespaced: false, Kind: "ClusterRole"},
 				{Name: "roles", Namespaced: true, Kind: "Role"},
 			},
 		},

--- a/test/fixtures.go
+++ b/test/fixtures.go
@@ -261,6 +261,8 @@ func SetupTestAPI(objects ...runtime.Object) (kubernetes.Interface, dynamic.Inte
 			APIResources: []metav1.APIResource{
 				{Name: "clusterroles", Namespaced: false, Kind: "ClusterRole"},
 				{Name: "roles", Namespaced: true, Kind: "Role"},
+				{Name: "clusterrolebindings", Namespaced: false, Kind: "ClusterRoleBinding"},
+				{Name: "rolebindings", Namespaced: true, Kind: "RoleBinding"},
 			},
 		},
 	}

--- a/test/fixtures.go
+++ b/test/fixtures.go
@@ -256,6 +256,12 @@ func SetupTestAPI(objects ...runtime.Object) (kubernetes.Interface, dynamic.Inte
 				{Name: "namespaces", Namespaced: false, Kind: "Namespace"},
 			},
 		},
+		{
+			GroupVersion: "rbac.authorization.k8s.io/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "roles", Namespaced: true, Kind: "Role"},
+			},
+		},
 	}
 	return k, dynamicClient
 }


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
* Alert on user-defined Roles and ClusterRoles that allow execing or attaching to pods.
* Alert on user-defined RoleBindings and ClusterRoleBindings that reference Roles or ClusterRoles allowing execing or attaching to pods.

### What alternative solution should we consider, if any?

The ClusterRole check factors out static names of built-in ClusterRoles that allow exec or attach. I chose not to match partial ClusterRole names like `system:*` or standard labels, because it is possible for user-defined ClusterRoles to be created with these same criteria. If future versions of Kubernetes add ClusterRoles with these permissions, those new ClusterRoles will need to be added to this check.