### PR TITLE
Add warning message for multi-schema checks in admission

### DIFF
--- a/pkg/validator/schema.go
+++ b/pkg/validator/schema.go
@@ -155,6 +155,9 @@ func hasExemptionAnnotation(objMeta metaV1.Object, checkID string) bool {
 // ApplyAllSchemaChecksToResourceProvider applies all available checks to a ResourceProvider
 func ApplyAllSchemaChecksToResourceProvider(conf *config.Configuration, resourceProvider *kube.ResourceProvider) ([]Result, error) {
 	results := []Result{}
+	if resourceProvider == nil {
+		return nil, errors.New("No resource provider set, cannot apply schema checks")
+	}
 	for _, resources := range resourceProvider.Resources {
 		kindResults, err := ApplyAllSchemaChecksToAllResources(conf, resourceProvider, resources)
 		if err != nil {
@@ -353,6 +356,10 @@ func applySchemaCheck(conf *config.Configuration, checkID string, test schemaTes
 	}
 	for groupkind := range check.AdditionalValidators {
 		if !passes {
+			break
+		}
+		if test.ResourceProvider == nil {
+			logrus.Warnf("No ResourceProvider available, check %s not work in this context (e.g. admission control)", checkID)
 			break
 		}
 		resources := test.ResourceProvider.Resources[groupkind]

--- a/pkg/validator/schema.go
+++ b/pkg/validator/schema.go
@@ -359,7 +359,7 @@ func applySchemaCheck(conf *config.Configuration, checkID string, test schemaTes
 			break
 		}
 		if test.ResourceProvider == nil {
-			logrus.Warnf("No ResourceProvider available, check %s not work in this context (e.g. admission control)", checkID)
+			logrus.Warnf("No ResourceProvider available, check %s will not work in this context (e.g. admission control)", checkID)
 			break
 		}
 		resources := test.ResourceProvider.Resources[groupkind]


### PR DESCRIPTION
This PR fixes https://github.com/FairwindsOps/polaris/issues/838

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Log a warning message instead of panicking when there's a multi-resource check enabled in admission

### What changes did you make?
Also added a flag for the cert dir

### What alternative solution should we consider, if any?

