### PR TITLE
Fix CI tag filters and re-enable docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,9 @@ workflows:
   release:
     jobs:
       - test
+          filters:
+            tags:
+              only: /.*/
       - build_and_push:
           context: org-global
           requires:
@@ -182,12 +185,16 @@ workflows:
           filters:
             branches:
               ignore: /pull\/[0-9]+/
+            tags:
+              ignore: /^testing-.*/
       - test_k8s:
           requires:
             - build_and_push
           filters:
             branches:
               ignore: /pull\/[0-9]+/
+            tags:
+              ignore: /^testing-.*/
       - oss-docs/publish-docs:
           repository: polaris
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ workflows:
 
   release:
     jobs:
-      - test
+      - test:
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,6 +194,4 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              # ifetch: temporary while testing
-              #ignore: /^testing-.*/
-              ignore: /.*/
+              ignore: /^testing-.*/


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
* Add tag-filters to the rest of the job in the CircleCI workflow, so the workflow runs when a tag is pushed.
* Re-enable docs build/push after goreleaser/CI updates.

### What changes did you make?

### What alternative solution should we consider, if any?

