### PR TITLE
Fix conflict between dangerousCapabilities and insecureCapabilities

### DIFF
--- a/checks/dangerousCapabilities.yaml
+++ b/checks/dangerousCapabilities.yaml
@@ -28,4 +28,4 @@ schema:
 
 mutations:
   - op: remove
-    path: /securityContext/capabilities
+    path: /securityContext/capabilities/add


### PR DESCRIPTION
This PR fixes an issue where the mutation for `dangerousCapabilities` interferes with the mutation for `insecureCapabilities`

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

### What changes did you make?
Make mutation for dangerousCapabilities more specific

### What alternative solution should we consider, if any?
There's a larger issue where mutations run in a non-deterministic order. There's also no defense against mutations doing conflicting or even opposite things (e.g. one might set cpu limits, and another remove cpu limits).
