### PR TITLE
Set the `automountServiceAccountToken` to ignore, `hasPrefix` and `hasSuffix` functions are available in the go template, exempt the prefix `system:` instead of indifidual entries for RBAC checks

### DIFF
--- a/checks/clusterrolePodExecAttach.yaml
+++ b/checks/clusterrolePodExecAttach.yaml
@@ -18,9 +18,8 @@ schemaString: |
                 - const: 'admin'
                 - const: "cluster-admin"
                 - const: "edit"
-                - const: "system:aggregate-to-edit"
-                - const: "system:controller:generic-garbage-collector"
-                - const: "system:controller:namespace-controller"
+                - pattern: '^system:'
+                - const: "gce:podsecuritypolicy:calico-sa"
     - properties:
         rules:
           type: array

--- a/checks/clusterrolebindingClusterAdmin.yaml
+++ b/checks/clusterrolebindingClusterAdmin.yaml
@@ -17,8 +17,8 @@ schemaString: |
               type: string
               anyOf:
                 - const: "cluster-admin"
-                - const: "system:controller:generic-garbage-collector"
-                - const: "system:controller:namespace-controller"
+                - pattern: '^system:'
+                - const: "gce:podsecuritypolicy:calico-sa"
     - required: ["roleRef"]
       properties:
         roleRef:
@@ -39,7 +39,7 @@ additionalSchemaStrings:
   rbac.authorization.k8s.io/ClusterRole: |
     type: object
     # Do not alert on default ClusterRoleBindings.
-    {{ if and (ne .metadata.name "cluster-admin") (ne .metadata.name "system:controller:generic-garbage-collector") (ne .metadata.name "system:controller:namespace-controller") }}
+    {{ if and (ne .metadata.name "cluster-admin") (not (hasPrefix .metadata.name "system:")) (ne .metadata.name "gce:podsecuritypolicy:calico-sa") }}
     required: ["metadata", "rules"]
     allOf:
       - properties:

--- a/checks/clusterrolebindingPodExecAttach.yaml
+++ b/checks/clusterrolebindingPodExecAttach.yaml
@@ -17,8 +17,8 @@ schemaString: |
               type: string
               anyOf:
                 - const: "cluster-admin"
-                - const: "system:controller:generic-garbage-collector"
-                - const: "system:controller:namespace-controller"
+                - pattern: '^system:'
+                - const: "gce:podsecuritypolicy:calico-sa"
     - required: ["roleRef"]
       properties:
         roleRef:
@@ -37,7 +37,7 @@ additionalSchemaStrings:
   rbac.authorization.k8s.io/ClusterRole: |
     type: object
     # Do not alert on default ClusterRoleBindings.
-    {{ if and (ne .metadata.name "cluster-admin") (ne .metadata.name "system:controller:generic-garbage-collector") (ne .metadata.name "system:controller:namespace-controller") }}
+    {{ if and (ne .metadata.name "cluster-admin") (not (hasPrefix .metadata.name "system:")) (ne .metadata.name "gce:podsecuritypolicy:calico-sa") }}
     required: ["metadata", "rules"]
     allOf:
       - properties:

--- a/docs/customization/custom-checks.md
+++ b/docs/customization/custom-checks.md
@@ -167,6 +167,18 @@ schemaString: |
               {{ end }}
 ```
 
+### Additional Go Template Functions
+
+These functions are also available in the GO template.
+
+* [hasPrefix](https://pkg.go.dev/strings#HasPrefix) - for example, `hasPrefix "string" "prefix"`
+* [hasSuffix](https://pkg.go.dev/strings#HasSuffix) - for example, `hasSuffix "string" "suffix"`
+
+For example, the `hasPrefix` function can be used in a template to determine whether a resource name starts with `system:`
+```
+{{ if hasPrefix .metadata.name "system:" }}
+```
+
 ## Multi-Resource Checks
 You can write checks that span multiple resources. This is helpful for ensuring e.g.
 that every Deployment has a PDB or an HPA associated with it.

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -16,7 +16,7 @@ checks:
   memoryRequestsMissing: warning
   memoryLimitsMissing: warning
   # security
-  automountServiceAccountToken: warning
+  automountServiceAccountToken: ignore
   hostIPCSet: danger
   hostPIDSet: danger
   linuxHardening: warning

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -223,7 +223,10 @@ func (check SchemaCheck) TemplateForResource(res interface{}) (*SchemaCheck, err
 	newCheck.AdditionalSchemaStrings = map[string]string{}
 
 	for kind, tmplString := range templateStrings {
-		tmpl := template.New(newCheck.ID)
+		tmpl := template.New(newCheck.ID).Funcs(template.FuncMap{
+			"hasPrefix": strings.HasPrefix,
+			"hasSuffix": strings.HasSuffix,
+		})
 		tmpl, err := tmpl.Parse(tmplString)
 		if err != nil {
 			return nil, err

--- a/test/checks/clusterrolePodExecAttach/success.gce_calico_clusterrole.yaml
+++ b/test/checks/clusterrolePodExecAttach/success.gce_calico_clusterrole.yaml
@@ -1,0 +1,9 @@
+# This succeeds because the clusterRole is an exempt name `gce:podsecuritypolicy:calico-sa`
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gce:podsecuritypolicy:calico-sa
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "*" ]
+    verbs: [ "*" ]

--- a/test/checks/clusterrolePodExecAttach/success.system_prefix.yaml
+++ b/test/checks/clusterrolePodExecAttach/success.system_prefix.yaml
@@ -1,0 +1,9 @@
+# This succeeds because the clusterRole has an exempt `system:` prefix.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "*" ]
+    verbs: [ "*" ]

--- a/test/checks/clusterrolebindingClusterAdmin/failure.binding_to_system_prefix.yaml
+++ b/test/checks/clusterrolebindingClusterAdmin/failure.binding_to_system_prefix.yaml
@@ -1,0 +1,35 @@
+# This fails because the clusterRoleBinding references a ClusterRole that uses all wildcards which happens to have a `system:` prefix.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  # The system: prefix does not cause this test to fail, but this test
+  # avoids incorectly ignoring user-created bindings to system ClusterRoles.
+  name: system:test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "*" ]
+    verbs: [ "*" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-binding-to-system-prefix-clusterrole
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser
+---
+# This Role exists so there is at least one Role for the additionalSchema to find.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: not-used
+  namespace: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods" ]
+    verbs: [ list ]

--- a/test/checks/clusterrolebindingClusterAdmin/success.gce_calico_binding.yaml
+++ b/test/checks/clusterrolebindingClusterAdmin/success.gce_calico_binding.yaml
@@ -1,0 +1,33 @@
+# This succeeds because the clusterRoleBinding is an exempt name `gce:podsecuritypolicy:calico-sa`
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "*" ]
+    verbs: [ "*" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gce:podsecuritypolicy:calico-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser
+---
+# This Role exists so there is at least one Role for the additionalSchema to find.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: not-used
+  namespace: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods" ]
+    verbs: [ list ]

--- a/test/checks/clusterrolebindingClusterAdmin/success.system_prefix_binding.yaml
+++ b/test/checks/clusterrolebindingClusterAdmin/success.system_prefix_binding.yaml
@@ -1,0 +1,33 @@
+# This succeeds because the clusterRoleBinding has an exempt `system:` prefix.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "*" ]
+    verbs: [ "*" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser
+---
+# This Role exists so there is at least one Role for the additionalSchema to find.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: not-used
+  namespace: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods" ]
+    verbs: [ list ]

--- a/test/checks/clusterrolebindingPodExecAttach/failure.binding_to_system_prefix.yaml
+++ b/test/checks/clusterrolebindingPodExecAttach/failure.binding_to_system_prefix.yaml
@@ -1,0 +1,35 @@
+# This fails because the clusterRoleBinding references a ClusterRole that uses all wildcards which happens to have a `system:` prefix.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  # The system: prefix does not cause this test to fail, but this test
+  # avoids incorectly ignoring user-created bindings to system ClusterRoles.
+  name: system:test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "*" ]
+    verbs: [ "*" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-binding-to-system-prefix-clusterrole
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser
+---
+# This Role exists so there is at least one Role for the additionalSchema to find.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: not-used
+  namespace: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods" ]
+    verbs: [ list ]

--- a/test/checks/clusterrolebindingPodExecAttach/success.gce_calico_binding.yaml
+++ b/test/checks/clusterrolebindingPodExecAttach/success.gce_calico_binding.yaml
@@ -1,0 +1,33 @@
+# This succeeds because the clusterRoleBinding is an exempt name `gce:podsecuritypolicy:calico-sa`
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "*" ]
+    verbs: [ "*" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gce:podsecuritypolicy:calico-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser
+---
+# This Role exists so there is at least one Role for the additionalSchema to find.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: not-used
+  namespace: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods" ]
+    verbs: [ list ]

--- a/test/checks/clusterrolebindingPodExecAttach/success.system_prefix_binding.yaml
+++ b/test/checks/clusterrolebindingPodExecAttach/success.system_prefix_binding.yaml
@@ -1,0 +1,33 @@
+# This succeeds because the clusterRoleBinding has an exempt `system:` prefix.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+  - apiGroups: [ "*" ]
+    resources: [ "*" ]
+    verbs: [ "*" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: testuser
+---
+# This Role exists so there is at least one Role for the additionalSchema to find.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: not-used
+  namespace: test
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods" ]
+    verbs: [ list ]


### PR DESCRIPTION
Note that this PR will merge into another feature branch, which is currently used with a subset of `Insights telemetry` users.

Internal Ticket: https://fairwinds.myjetbrains.com/youtrack/issue/FWI-3096/Update-RBAC-checks-to-exempt-the-system-prefix-instead-of-individual-resource-names

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
* Exempt additional resources from RBAC checks that are provided by Kube, or cloud providers.
* Set the `automountServiceAccountToken` to ignore in the default config
### What changes did you make?
* The RBAC checks `clusterrolebindingClusterAdmin` and `clusterrolebindingPodExecAttach` now exempt bindings that start with `system:`, instead of listing explicit strings.
* The RBAC check `clusterrolePodExecAttach` now exempt ClusterRoles that start with `system:`, instead of listing explicit strings.


### What alternative solution should we consider, if any?
We could continue to maintain individual exemptions like `system:controller:...`, but this list will likely grow with new Kube releases.