### PR TITLE
Fix #908 by generating release name

### DIFF
--- a/cmd/polaris/audit.go
+++ b/cmd/polaris/audit.go
@@ -143,7 +143,7 @@ func ProcessHelmTemplates(helmChart, helmValues string) (string, error) {
 	}
 	params := []string{
 		"template", helmChart,
-		helmChart,
+		"--generate-name",
 		"--output-dir",
 		dir,
 	}


### PR DESCRIPTION
This PR fixes #908 

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

The goal is to fix the helm chart auditing so it works for what I am wanting to do today (also makes it work per [the docs](https://github.com/FairwindsOps/polaris/blob/master/docs/infrastructure-as-code.md#audit-helm-charts)).

### What changes did you make?

I change the helm template command to have helm generate a release name instead of using the helm chart path as the release name (which is frequently not a valid release name).

### What alternative solution should we consider, if any?

You may want to hard-code the release name to something more self-explanatory if it shows up in the output like `polarisReleaseName`.

### Testing

I tested the changes locally, and Polaris audit now works instead of breaking quickly. Note, I also ran `go test`.