### PR TITLE
preserve ordering of resources

### DIFF
--- a/cmd/polaris/fix.go
+++ b/cmd/polaris/fix.go
@@ -113,20 +113,19 @@ var fixCommand = &cobra.Command{
 
 			updatedYamlContent := ""
 			if len(allMutations) > 0 {
-				for _, resources := range kubeResources.Resources {
-					for _, resource := range resources {
-						key := fmt.Sprintf("%s/%s/%s", resource.Kind, resource.Resource.GetName(), resource.Resource.GetNamespace())
-						mutations := allMutations[key]
-						mutatedYamlContent, err := mutation.ApplyAllMutations(string(resource.OriginalObjectYAML), mutations)
-						if err != nil {
-							logrus.Errorf("Error applying schema mutations to the resource %s: %v", key, err)
-							os.Exit(1)
-						}
-						if updatedYamlContent != "" {
-							updatedYamlContent += "\n---\n"
-						}
-						updatedYamlContent += mutatedYamlContent
+				for _, resource := range kubeResources.Resources {
+					key := fmt.Sprintf("%s/%s/%s", resource.Kind, resource.Resource.GetName(), resource.Resource.GetNamespace())
+					fmt.Println("resource", key)
+					mutations := allMutations[key]
+					mutatedYamlContent, err := mutation.ApplyAllMutations(string(resource.OriginalObjectYAML), mutations)
+					if err != nil {
+						logrus.Errorf("Error applying schema mutations to the resource %s: %v", key, err)
+						os.Exit(1)
 					}
+					if updatedYamlContent != "" {
+						updatedYamlContent += "\n---\n"
+					}
+					updatedYamlContent += mutatedYamlContent
 				}
 			}
 

--- a/pkg/kube/resources_test.go
+++ b/pkg/kube/resources_test.go
@@ -90,7 +90,7 @@ func TestAddResourcesFromReader(t *testing.T) {
 
 	assert.Equal(t, 0, len(resources.Nodes), "Should not have any nodes")
 
-	assert.Equal(t, 6, len(resources.Resources), "Should have one controller")
+	assert.Equal(t, 6, len(resources.Resources), "Should have 6 resources")
 	deployment := funk.Find(resources.Resources, func(res GenericResource) bool {
 		return res.Resource.GroupVersionKind().Kind == "Deployment"
 	}).(GenericResource)

--- a/pkg/validator/controller_test.go
+++ b/pkg/validator/controller_test.go
@@ -72,7 +72,10 @@ func TestControllerLevelChecks(t *testing.T) {
 			Severity: "danger",
 			Category: "Reliability",
 		}
-		for _, controller := range res.Resources["Deployment"] {
+		for _, controller := range res.Resources {
+			if controller.Resource.GroupVersionKind().Kind != "Deployment" {
+				continue
+			}
 			actualResult, err := applyControllerSchemaChecks(&c, nil, controller)
 			if err != nil {
 				panic(err)
@@ -96,7 +99,7 @@ func TestControllerLevelChecks(t *testing.T) {
 
 	res, err := kube.CreateResourceProviderFromPath("../kube/test_files/test_1")
 	assert.Equal(t, nil, err, "Error should be nil")
-	assert.Equal(t, 11, res.Resources.GetLength())
+	assert.Equal(t, 11, len(res.Resources))
 	testResources(res)
 
 	replicaSpec := map[string]interface{}{"replicas": 2}
@@ -111,7 +114,7 @@ func TestControllerLevelChecks(t *testing.T) {
 	k8s, dynamicClient := test.SetupTestAPI(&d1, &p1, &d2, &p2)
 	res, err = kube.CreateResourceProviderFromAPI(context.Background(), k8s, "test", dynamicClient, conf.Configuration{})
 	assert.Equal(t, err, nil, "error should be nil")
-	assert.Equal(t, 2, res.Resources.GetLength(), "Should have two controllers")
+	assert.Equal(t, 2, len(res.Resources), "Should have two controllers")
 	testResources(res)
 }
 

--- a/pkg/validator/schema.go
+++ b/pkg/validator/schema.go
@@ -173,18 +173,10 @@ func hasExemptionAnnotation(objMeta metaV1.Object, checkID string) bool {
 
 // ApplyAllSchemaChecksToResourceProvider applies all available checks to a ResourceProvider
 func ApplyAllSchemaChecksToResourceProvider(conf *config.Configuration, resourceProvider *kube.ResourceProvider) ([]Result, error) {
-	results := []Result{}
 	if resourceProvider == nil {
 		return nil, errors.New("No resource provider set, cannot apply schema checks")
 	}
-	for _, resources := range resourceProvider.Resources {
-		kindResults, err := ApplyAllSchemaChecksToAllResources(conf, resourceProvider, resources)
-		if err != nil {
-			return results, err
-		}
-		results = append(results, kindResults...)
-	}
-	return results, nil
+	return ApplyAllSchemaChecksToAllResources(conf, resourceProvider, resourceProvider.Resources)
 }
 
 // ApplyAllSchemaChecksToAllResources applies available checks to a list of resources
@@ -381,7 +373,7 @@ func applySchemaCheck(conf *config.Configuration, checkID string, test schemaTes
 			logrus.Warnf("No ResourceProvider available, check %s will not work in this context (e.g. admission control)", checkID)
 			break
 		}
-		resources := test.ResourceProvider.Resources[groupkind]
+		resources := test.ResourceProvider.Resources.GetAllOfGroupKind(groupkind)
 		namespace := test.Resource.ObjectMeta.GetNamespace()
 		if test.Resource.Kind == "Namespace" {
 			namespace = test.Resource.ObjectMeta.GetName()

--- a/test/mutation_test.go
+++ b/test/mutation_test.go
@@ -51,9 +51,8 @@ func TestMutations(t *testing.T) {
 			assert.Len(t, results, 1)
 			allMutations := mutation.GetMutationsFromResults(results)
 			assert.Len(t, allMutations, 1)
-			for _, resources := range tc.resources.Resources {
-				assert.Len(t, resources, 1)
-				key := fmt.Sprintf("%s/%s/%s", resources[0].Kind, resources[0].Resource.GetName(), resources[0].Resource.GetNamespace())
+			for _, resource := range tc.resources.Resources {
+				key := fmt.Sprintf("%s/%s/%s", resource.Kind, resource.Resource.GetName(), resource.Resource.GetNamespace())
 				mutations := allMutations[key]
 				yamlContent, err := mutation.ApplyAllMutations(tc.manifest, mutations)
 				assert.NoError(t, err)


### PR DESCRIPTION
This PR fixes issues where `polaris fix` changes the ordering of resources

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Preserve ordering of resources in YAML files

### What changes did you make?
Turns a `map` into an array, then fixed lots of tests

### What alternative solution should we consider, if any?
Maybe find another way to track order?
