### PR TITLE
chore(ci): Upgrade Github CI/CD to non-deprecated actions

### DIFF
--- a/.github/actions/setup-polaris/Dockerfile
+++ b/.github/actions/setup-polaris/Dockerfile
@@ -1,6 +1,6 @@
 # The action uses an own Dockerfile on purpose because the root Dockerfile takes way too long to build for an action
 
-FROM alpine:3.10
+FROM alpine:3.17
 
 RUN	apk add --no-cache \
   bash \

--- a/.github/actions/setup-polaris/get_polaris.sh
+++ b/.github/actions/setup-polaris/get_polaris.sh
@@ -17,4 +17,4 @@ mkdir polaris
 tar -xzf $TARGET_FILE -C polaris
 rm $TARGET_FILE
 echo "polaris" >> $GITHUB_PATH
-echo "::set-output name=version::$INPUT_VERSION"
+echo "version=$INPUT_VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v7
         with:
           exempt-issue-labels: pinned
           stale-pr-label: stale

--- a/.github/workflows/test_setup.yml
+++ b/.github/workflows/test_setup.yml
@@ -7,7 +7,7 @@ jobs:
   build-int:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup polaris
         uses: ./.github/actions/setup-polaris
         with:
@@ -18,7 +18,7 @@ jobs:
   build-ext:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup polaris
         uses: fairwindsops/polaris/.github/actions/setup-polaris@master
         with:


### PR DESCRIPTION
This PR fixes #

## Checklist
* [x] I have signed the CLA
* [X] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Several of the workflows in this repository (both internal and the setup polaris action exposed externally) are affected by deprecation warnings by Github.

### What changes did you make?
This PR resolves all deprecation warnings by bumping third party workflows used, as well as some syntax changes in the setup-polaris workflow.

### What alternative solution should we consider, if any?
As of now I don't see any other ways to resolve these deprecation warnings. 
