### PR TITLE
tweak net listener to localhost - removing unwanted popup

### DIFF
--- a/pkg/auth/login.go
+++ b/pkg/auth/login.go
@@ -85,7 +85,7 @@ func HandleLogin(insightsHost string) error {
 
 	var user, token, organization string
 	if answer == loginUsingBrowser {
-		listener, err := net.Listen("tcp", ":0")
+		listener, err := net.Listen("tcp", "localhost:0")
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
This PR fixes #

## Checklist
* [X] I have signed the CLA
* [X] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
When leaving the TCP listener "open", `macos` will prompt the user for permission. By setting it to `localhost` it does not

### What changes did you make?

### What alternative solution should we consider, if any?

