### PR TITLE
Redirect user to cluster action-items instead of cluster overview

### DIFF
--- a/cmd/polaris/audit.go
+++ b/cmd/polaris/audit.go
@@ -173,7 +173,7 @@ var auditCmd = &cobra.Command{
 				os.Exit(1)
 			}
 			logrus.Println("Success! You can see your results at:")
-			logrus.Printf("%s/orgs/%s/clusters/%s\n", insightsHost, auth.Organization, clusterName)
+			logrus.Printf("%s/orgs/%s/clusters/%s/action-items\n", insightsHost, auth.Organization, clusterName)
 		} else {
 			outputAudit(auditData, auditOutputFile, auditOutputURL, auditOutputFormat, useColor, onlyShowFailedTests)
 		}


### PR DESCRIPTION
This PR fixes #

## Checklist
* [X] I have signed the CLA
* [X] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
- redirect user to cluster action-items instead of cluster overview

### What changes did you make?

### What alternative solution should we consider, if any?

