### PR TITLE
fix cert dir arg

### DIFF
--- a/cmd/polaris/webhook.go
+++ b/cmd/polaris/webhook.go
@@ -53,6 +53,7 @@ var webhookCmd = &cobra.Command{
 			CertDir: certDir,
 			Port:    webhookPort,
 			WebhookServer: webhook.NewServer(webhook.Options{
+				CertDir: certDir,
 				CertName: "tls.crt",
 				KeyName:  "tls.key",
 			}),


### PR DESCRIPTION
This PR fixes an issue where the webhook server can't find certs. Introduced in 8.1 via https://github.com/FairwindsOps/polaris/pull/951/files#diff-19034316a5a02110439c93752c79380bc51d15f761e35c171dba963947046a20R27-R58

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Fix webhook certificate handling

### What changes did you make?
Pass certDir option to the right place

### What alternative solution should we consider, if any?

