### PR TITLE
Add option to filter audit results by severity level

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -52,6 +52,9 @@ webhook
     --resource string                 Audit a specific resource, in the format namespace/kind/version/name, e.g. nginx-ingress/Deployment.apps/v1/default-backend.
     --set-exit-code-below-score int   Set an exit code of 4 when the score is below this threshold (1-100).
     --set-exit-code-on-danger         Set an exit code of 3 when the audit contains danger-level issues.
+    --severity string                 Severity level used to filter results. Behaves like log levels. 'danger' is the least verbose (warning, danger)
+    --skip-ssl-validation             Skip https certificate verification
+    --upload-insights                 Upload scan results to Fairwinds Insights
 
 # webhook flags
     --disable-webhook-config-installer   disable the installer in the webhook server, so it won't install webhook configuration resources during bootstrapping.


### PR DESCRIPTION
This PR fixes #

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description

To address https://github.com/FairwindsOps/polaris/issues/754, I've chosen to implement verbosity options for displaying audit results in the same manner as log levels. `danger` is the least verbose option and will only include results of that severity. `warning` is the medium verbosity option and will only display results of severity `warning` or `danger`. By default, all results will be displayed. This will still function with `--only-show-failed-tests` and behave as expected.

### What's the goal of this PR?

Add verbosity options to the `audit` subcommand in the polaris CLI

### What changes did you make?

Low verbosity (`danger`)

```
./polaris audit --audit-path=manifests --severity=danger | wc -l


Want more? Automate Polaris for free with Fairwinds Insights!
🚀 https://fairwinds.com/insights-signup/polaris 🚀
     116
```

Medium verbosity (`warning`, also implies inclusion of `danger`)

```
/polaris audit --audit-path=manifests --severity=warning | wc -l


Want more? Automate Polaris for free with Fairwinds Insights!
🚀 https://fairwinds.com/insights-signup/polaris 🚀
     268
```

### What alternative solution should we consider, if any?

