### PR TITLE
Fix numerical resource ranges

### DIFF
--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -143,6 +143,9 @@ func (max resourceMaximum) Validate(path string, data interface{}, errs *[]jsons
 }
 
 func parseQuantity(i interface{}) (resource.Quantity, *[]jsonschema.ValError) {
+	if resNum, ok := i.(float64); ok {
+		i = fmt.Sprintf("%f", resNum)
+	}
 	resStr, ok := i.(string)
 	if !ok {
 		return resource.Quantity{}, &[]jsonschema.ValError{

--- a/test/checks/resourceRange/check.yaml
+++ b/test/checks/resourceRange/check.yaml
@@ -1,0 +1,32 @@
+containers:
+  exclude:
+  - initContainer
+successMessage: Resource limits are within the required range
+failureMessage: Resource limits should be within the required range
+category: Resources
+target: Container
+schema:
+  '$schema': http://json-schema.org/draft-07/schema
+  type: object
+  required:
+  - resources
+  properties:
+    resources:
+      type: object
+      required:
+      - limits
+      properties:
+        limits:
+          type: object
+          required:
+          - memory
+          - cpu
+          properties:
+            memory:
+              type: string
+              resourceMinimum: 100Mi # 104857600 bytes
+              resourceMaximum: 6G
+            cpu:
+              type: string
+              resourceMinimum: 100m
+              resourceMaximum: "2"

--- a/test/checks/resourceRange/failure.cpu-number.yaml
+++ b/test/checks/resourceRange/failure.cpu-number.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    app.kubernetes.io/name: nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    resources:
+      limits:
+        memory: 250Mi
+        cpu: 0.05

--- a/test/checks/resourceRange/failure.mem-number.yaml
+++ b/test/checks/resourceRange/failure.mem-number.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    app.kubernetes.io/name: nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    resources:
+      limits:
+        memory: 104857599
+        cpu: 1

--- a/test/checks/resourceRange/success.cpu-number.yaml
+++ b/test/checks/resourceRange/success.cpu-number.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    app.kubernetes.io/name: nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    resources:
+      limits:
+        memory: 250Mi
+        cpu: 1.5

--- a/test/checks/resourceRange/success.mem-number.yaml
+++ b/test/checks/resourceRange/success.mem-number.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    app.kubernetes.io/name: nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    resources:
+      limits:
+        memory: 104857600
+        cpu: 1


### PR DESCRIPTION
This PR fixes an issue when parsing numerical resource ranges

Fixes issue https://github.com/FairwindsOps/polaris/issues/979

This one was really hard to track down. It actually doesn't trip up our tests, because we parse and validate known Kinds properly. The issue seems to be for unknown resources like the BuildConfig referenced in #979 

I've validated that the case provided in the issue now works.

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Support numerical CPU and memory amounts

### What changes did you make?
Add a case to handle numbers

### What alternative solution should we consider, if any?

