### PR TITLE
chore: fix privilegeEscalationAllowed check

### DIFF
--- a/checks/privilegeEscalationAllowed.yaml
+++ b/checks/privilegeEscalationAllowed.yaml
@@ -26,22 +26,13 @@ schema:
     properties:
       securityContext:
         $ref: "#/definitions/goodSecurityContext"
+  - properties:
       containers:
         type: array
         items:
           properties:
             securityContext:
               $ref: "#/definitions/notBadSecurityContext"
-  - properties:
-      containers:
-        type: array
-        items:
-          required:
-          - securityContext
-          properties:
-            securityContext:
-              $ref: "#/definitions/goodSecurityContext"
-
 mutations:
   - op: add
     path: /securityContext/allowPrivilegeEscalation


### PR DESCRIPTION
This PR fixes #997 

## Checklist
* [x] I have signed the CLA
* [ ] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Fixes the Problem of this Issue #997 
### What changes did you make?
I removed the requirement that the container must explicitly have the following configuration:
``` yaml
securityContext:
  allowPrivilegeEscalation: false
```
However, the check still fails when the configuration is as follows:
``` yaml
securityContext:
  allowPrivilegeEscalation: true
```
What's important to understand now is that when you omit any `securityContext` configuration entirely, the check will pass. This is because Kubernetes defaults to a configuration where `allowPrivilegeEscalation` is set to `false`.
### What alternative solution should we consider, if any?
-
