### PR TITLE
FWI-5385 Add quiet flag to polaris audit CLI command to suppress 'upload to Insights' prompt

### DIFF
--- a/cmd/polaris/audit.go
+++ b/cmd/polaris/audit.go
@@ -57,6 +57,7 @@ var (
 	skipSslValidation   bool
 	uploadInsights      bool
 	clusterName         string
+	quiet               bool
 )
 
 func init() {
@@ -80,6 +81,7 @@ func init() {
 	auditCmd.PersistentFlags().BoolVar(&skipSslValidation, "skip-ssl-validation", false, "Skip https certificate verification")
 	auditCmd.PersistentFlags().BoolVar(&uploadInsights, "upload-insights", false, "Upload scan results to Fairwinds Insights")
 	auditCmd.PersistentFlags().StringVar(&clusterName, "cluster-name", "", "Set --cluster-name to a descriptive name for the cluster you're auditing")
+	auditCmd.PersistentFlags().BoolVar(&quiet, "quiet", false, "Suppress the 'upload to Insights' prompt.")
 }
 
 var auditCmd = &cobra.Command{
@@ -181,8 +183,10 @@ var auditCmd = &cobra.Command{
 			os.Stderr.WriteString(fmt.Sprintf("\n\n%s/orgs/%s/clusters/%s/action-items\n\n", insightsHost, auth.Organization, clusterName))
 		} else {
 			outputAudit(auditData, auditOutputFile, auditOutputURL, auditOutputFormat, useColor, onlyShowFailedTests, severityLevel)
-			os.Stderr.WriteString("\n\n🚀 Upload your Polaris findings to Fairwinds Insights to see remediation advice, add teammates, integrate with Slack or Jira, and more:")
-			os.Stderr.WriteString("\n\n❯ polaris " + strings.Join(os.Args[1:], " ") + " --upload-insights --cluster-name=my-cluster\n\n")
+			if !quiet {
+				os.Stderr.WriteString("\n\n🚀 Upload your Polaris findings to Fairwinds Insights to see remediation advice, add teammates, integrate with Slack or Jira, and more:")
+				os.Stderr.WriteString("\n\n❯ polaris " + strings.Join(os.Args[1:], " ") + " --upload-insights --cluster-name=my-cluster\n\n")
+			}
 		}
 
 		summary := auditData.GetSummary()


### PR DESCRIPTION
…sights' prompt


This PR addresses #1011 

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description

Adds the following flag to the `polaris audit` subcommand:

```
--quiet                           Suppress the 'upload to Insights' prompt.
```

### What's the goal of this PR?

### What changes did you make?


```
# before
go run main.go audit --audit-path ~/git/fairwinds/charts/stable/insights-agent/insights-manifest.yaml --only-show-failed-tests true --format=pretty

...
Pod insights-insights-agent-delete-jobs
    metadataAndNameMismatched            😬 Warning
        Reliability - Label app.kubernetes.io/name must match metadata.name
    priorityClassNotSet                  😬 Warning
        Reliability - Priority class should be set
    topologySpreadConstraint             😬 Warning
        Reliability - Pod should be configured with a valid topology spread constraint
    automountServiceAccountToken         😬 Warning
        Security - The ServiceAccount will be automounted
    missingNetworkPolicy                 😬 Warning
        Security - A NetworkPolicy should match pod labels and contain applied egress and ingress rules
  Container test
    livenessProbeMissing                 😬 Warning
        Reliability - Liveness probe should be configured
    readinessProbeMissing                😬 Warning
        Reliability - Readiness probe should be configured



🚀 Upload your Polaris findings to Fairwinds Insights to see remediation advice, add teammates, integrate with Slack or Jira, and more:
```

```
# after
➜  polaris git:(8.3.0) ✗ go run main.go audit --audit-path ~/git/fairwinds/charts/stable/insights-agent/insights-manifest.yaml --only-show-failed-tests true --format=pretty --quiet

...
Pod insights-insights-agent-delete-jobs
    metadataAndNameMismatched            😬 Warning
        Reliability - Label app.kubernetes.io/name must match metadata.name
    automountServiceAccountToken         😬 Warning
        Security - The ServiceAccount will be automounted
    missingNetworkPolicy                 😬 Warning
        Security - A NetworkPolicy should match pod labels and contain applied egress and ingress rules
    priorityClassNotSet                  😬 Warning
        Reliability - Priority class should be set
    topologySpreadConstraint             😬 Warning
        Reliability - Pod should be configured with a valid topology spread constraint
  Container test
    livenessProbeMissing                 😬 Warning
        Reliability - Liveness probe should be configured
    readinessProbeMissing                😬 Warning
        Reliability - Readiness probe should be configured
```

### What alternative solution should we consider, if any?

