### PR TITLE
FWI-5232 Conditional expressions should be at very top of additionalSchemaStrings

### DIFF
--- a/checks/clusterrolebindingClusterAdmin.yaml
+++ b/checks/clusterrolebindingClusterAdmin.yaml
@@ -37,10 +37,10 @@ schemaString: |
                 const: "cluster-admin"
 additionalSchemaStrings:
   rbac.authorization.k8s.io/ClusterRole: |
-    type: object
-    # Do not alert on default ClusterRoleBindings.
     {{ if (ne .roleRef.name "view") }}
     {{ if and (ne .metadata.name "cluster-admin") (not (hasPrefix .metadata.name "system:")) (ne .metadata.name "gce:podsecuritypolicy:calico-sa") }}
+    # Do not alert on default ClusterRoleBindings.
+    type: object
     required: ["metadata", "rules"]
     allOf:
       - properties:

--- a/checks/rolebindingClusterAdminClusterRole.yaml
+++ b/checks/rolebindingClusterAdminClusterRole.yaml
@@ -45,10 +45,10 @@ schemaString: |
                 const: "cluster-admin"
 additionalSchemaStrings:
   rbac.authorization.k8s.io/ClusterRole: |
-    type: object
-    # This schema is validated for all roleBindings, regardless of their roleRef.
     {{ if eq .roleRef.kind "ClusterRole" }}
     {{ if and (not (hasPrefix .metadata.name "system:")) (ne .metadata.name "gce:podsecuritypolicy:calico-sa") }}
+    # This schema is validated for all roleBindings, regardless of their roleRef.
+    type: object
     required: ["metadata", "rules"]
     allOf:
       - properties:

--- a/checks/rolebindingClusterRolePodExecAttach.yaml
+++ b/checks/rolebindingClusterRolePodExecAttach.yaml
@@ -43,10 +43,10 @@ schemaString: |
               minLength: 1
 additionalSchemaStrings:
   rbac.authorization.k8s.io/ClusterRole: |
-    type: object
-    # This schema is validated for all roleBindings, regardless of their roleRef.
     {{ if eq .roleRef.kind "ClusterRole" }}
     {{ if and (not (hasPrefix .metadata.name "system:")) (ne .metadata.name "gce:podsecuritypolicy:calico-sa") }}
+    # This schema is validated for all roleBindings, regardless of their roleRef.
+    type: object
     required: ["metadata", "rules"]
     allOf:
       - properties:

--- a/checks/rolebindingRolePodExecAttach.yaml
+++ b/checks/rolebindingRolePodExecAttach.yaml
@@ -46,10 +46,10 @@ schemaString: |
               minLength: 1
 additionalSchemaStrings:
   rbac.authorization.k8s.io/Role: |
-    type: object
-    # This schema is validated for all roleBindings, regardless of their roleRef.
     {{ if eq .roleRef.kind "Role" }}
     {{ if and (not (hasPrefix .metadata.name "system:")) (ne .metadata.name "gce:podsecuritypolicy:calico-sa") }}
+    # This schema is validated for all roleBindings, regardless of their roleRef.
+    type: object
     required: ["metadata", "rules"]
     allOf:
       - properties:

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
+	github.com/fairwindsops/controller-utils v0.3.0
 	github.com/fairwindsops/insights-plugins/plugins/workloads v0.0.0-20230601204422-5c789e15990c
 	github.com/fatih/color v1.15.0
 	github.com/gobuffalo/packr/v2 v2.8.3
@@ -30,7 +31,6 @@ require (
 	github.com/emicklei/go-restful/v3 v3.10.1 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
-	github.com/fairwindsops/controller-utils v0.3.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect

--- a/test/checks/rolebindingClusterAdminClusterRole/success.role_with_no_cluster_roles.yaml
+++ b/test/checks/rolebindingClusterAdminClusterRole/success.role_with_no_cluster_roles.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test
+  labels:
+    role: service
+    tier: backend
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+rules:
+  - apiGroups: [""]
+    resources: [services]
+    verbs: [get, list]
+---
+# check when there are no cluster roles present
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  kind: Role
+  name: test
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: test

--- a/test/checks/rolebindingClusterRolePodExecAttach/success.role_with_no_cluster_roles.yaml
+++ b/test/checks/rolebindingClusterRolePodExecAttach/success.role_with_no_cluster_roles.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test
+  labels:
+    role: service
+    tier: backend
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+rules:
+  - apiGroups: [""]
+    resources: [services]
+    verbs: [get, list]
+---
+# check when there are no cluster roles present
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  kind: Role
+  name: test
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: test

--- a/test/checks/rolebindingRolePodExecAttach/success.role_with_no_cluster_roles.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/success.role_with_no_cluster_roles.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test
+  labels:
+    role: service
+    tier: backend
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+rules:
+  - apiGroups: [""]
+    resources: [services]
+    verbs: [get, list]
+---
+# check when there are no cluster roles present
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+roleRef:
+  kind: Role
+  name: test
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: test


### PR DESCRIPTION
This PR fixes #1003

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description

Polaris checks utilize `additionalSchemaStrings`, an additional section of jsonschema that will only evaluate if the object conforms to `schemaString`. The conditional statements in `additionalSchemaStrings` need to be arranged in a manner such that when there's nothing to evaluate, the string is empty (not the object therein).

### What's the goal of this PR?

Fix false positives reported when running the Polaris CLI for the following checks:

* clusterrolebindingClusterAdmin
* rolebindingClusterAdminClusterRole
* rolebindingClusterRolePodExecAttach
* rolebindingRolePodExecAttach

### What changes did you make?

adjust the ordering of conditional expressions in `additionalSchemaStrings`:

e.g.

```
 additionalSchemaStrings:
   rbac.authorization.k8s.io/ClusterRole: |
-    type: object
-    # This schema is validated for all roleBindings, regardless of their roleRef.
     {{ if eq .roleRef.kind "ClusterRole" }}
     {{ if and (not (hasPrefix .metadata.name "system:")) (ne .metadata.name "gce:podsecuritypolicy:calico-sa") }}
+    # This schema is validated for all roleBindings, regardless of their roleRef.
+    type: object
```

so that there is not an empty object being evaluated, but rather an empty string

I've also added success test cases as a regression check

### What alternative solution should we consider, if any?

