### PR TITLE
fix missing PDB check

### DIFF
--- a/checks/missingPodDisruptionBudget.yaml
+++ b/checks/missingPodDisruptionBudget.yaml
@@ -9,12 +9,18 @@ schema:
   '$schema': http://json-schema.org/draft-07/schema
   type: object
   properties:
-    metadata:
+    spec:
       type: object
       properties:
-        labels:
+        template:
           type: object
-          minProperties: 1
+          properites:
+            metadata:
+              type: object
+              properties:
+                labels:
+                  type: object
+                  minProperties: 1
 additionalSchemaStrings:
   policy/PodDisruptionBudget: |
     type: object
@@ -30,7 +36,7 @@ additionalSchemaStrings:
               matchLabels:
                 type: object
                 anyOf:
-                {{ range $key, $value := .metadata.labels }}
+                {{ range $key, $value := .spec.template.metadata.labels }}
                 - properties:
                     "{{ $key }}":
                       type: string

--- a/test/checks/missingPodDisruptionBudget/failure.wrong-place.yaml
+++ b/test/checks/missingPodDisruptionBudget/failure.wrong-place.yaml
@@ -2,12 +2,11 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: zookeeper
+  labels:
+    app.kubernetes.io/name: zookeeper
+    foo: bar
 spec:
   template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: zookeeper
-        foo: bar
     spec:
       containers:
       - name: zookeeper

--- a/test/checks/missingPodDisruptionBudget/success.many.yaml
+++ b/test/checks/missingPodDisruptionBudget/success.many.yaml
@@ -2,10 +2,11 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: zookeeper
-  labels:
-    app.kubernetes.io/name: zookeeper
 spec:
   template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: zookeeper
     spec:
       containers:
       - name: zookeeper


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
The PDB's `matchLabels` should match the labels on the _pod_, not the deployment. Looks like we were checking the latter. This fixes it.

### What changes did you make?
Small tweak to the schema, added tests

