### PR TITLE
fix typo for minAvailable and maxAvailable

### DIFF
--- a/test/checks/pdbDisruptionsIsZero/success.both.yaml
+++ b/test/checks/pdbDisruptionsIsZero/success.both.yaml
@@ -5,5 +5,5 @@ metadata:
   labels:
     env: test
 spec:
-  minAvaiable: 5
+  minAvailable: 5
   maxUnavailable: 10%

--- a/test/checks/pdbDisruptionsIsZero/success.min.yaml
+++ b/test/checks/pdbDisruptionsIsZero/success.min.yaml
@@ -5,4 +5,4 @@ metadata:
   labels:
     env: test
 spec:
-  minAvaiable: 5
+  minAvailable: 5


### PR DESCRIPTION
This PR fixes typos

## Checklist
* [X] I have signed the CLA
* [X] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
- fix typo for `minAvailable` and `maxAvailable`

### What changes did you make?

### What alternative solution should we consider, if any?

