### PR TITLE
INSIGHTS-90 - implement HPA minAvailable and HPA maxAvailable checks

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@ meta:
 
 ## Unreleased
 * Change `metadataAndNameMismatched` to `metadataAndInstanceMismatched`
+* Add `hpaMaxAvailability` and `hpaMinAvailability` check
 
 ## 8.1.1
 * Add category for `metadataAndNameMismatched`.

--- a/docs/checks/reliability.md
+++ b/docs/checks/reliability.md
@@ -19,6 +19,8 @@ key | default | description
 `missingPodDisruptionBudget` | `warning` | Fails when PDB is missing.
 `metadataAndInstanceMismatched` | `warning` | Fails when label `app.kubernetes.io/instance` and `metadata.name` mismatch
 `topologySpreadConstraint` | `warning` | Fails when there is no topology spread constraint on the pod
+`hpaMaxAvailability` | `warning` | Fails when `maxAvailable` lesser or equal than `minAvailable` (if defined) for a HorizontalPodAutoscaler
+`hpaMinAvailability` | `warning` | Fails when `minAvailable` (if defined) lesser or equal to one for a HorizontalPodAutoscaler
 
 ## Background
 

--- a/pkg/config/checks.go
+++ b/pkg/config/checks.go
@@ -67,6 +67,8 @@ var (
 		"clusterrolebindingClusterAdmin",
 		"rolebindingClusterAdminClusterRole",
 		"rolebindingClusterAdminRole",
+		"hpaMaxAvailability",
+		"hpaMinAvailability",
 	}
 
 	// BuiltInChecks contains the checks that come pre-installed w/ Polaris

--- a/pkg/config/checks/hpaMaxAvailability.yaml
+++ b/pkg/config/checks/hpaMaxAvailability.yaml
@@ -1,4 +1,4 @@
 successMessage: HPA has a valid max and min replica configuration
-failureMessage: HPA maxReplicas should be greater than minReplicas
+failureMessage: HPA maxReplicas and minReplicas should be different 
 category: Reliability
 target: autoscaling/HorizontalPodAutoscaler

--- a/pkg/config/checks/hpaMaxAvailability.yaml
+++ b/pkg/config/checks/hpaMaxAvailability.yaml
@@ -1,0 +1,4 @@
+successMessage: HPA has a valid max and min replica configuration
+failureMessage: HPA maxReplicas should be greater than minReplicas
+category: Reliability
+target: autoscaling/HorizontalPodAutoscaler

--- a/pkg/config/checks/hpaMinAvailability.yaml
+++ b/pkg/config/checks/hpaMinAvailability.yaml
@@ -1,0 +1,14 @@
+successMessage: HPA has a valid min replica configuration
+failureMessage: HPA maxReplicas should be greater than minReplicas
+category: Reliability
+target: autoscaling/HorizontalPodAutoscaler
+schema:
+  "$schema": http://json-schema.org/draft-07/schema#
+  type: object
+  properties:
+    spec:
+      type: object
+      properties:
+        minReplicas:
+          type: integer
+          minimum: 2

--- a/pkg/config/default.yaml
+++ b/pkg/config/default.yaml
@@ -10,6 +10,8 @@ checks:
   pdbDisruptionsIsZero: warning
   missingPodDisruptionBudget: warning
   topologySpreadConstraint: warning
+  hpaMaxAvailability: warning
+  hpaMinAvailability: warning
 
   # efficiency
   cpuRequestsMissing: warning

--- a/pkg/config/examples/config-full.yaml
+++ b/pkg/config/examples/config-full.yaml
@@ -10,6 +10,8 @@ checks:
   pdbDisruptionsIsZero: warning
   missingPodDisruptionBudget: warning
   metadataAndInstanceMismatched: warning
+  hpaMaxAvailability: warning
+  hpaMinAvailability: warning
 
   # efficiency
   cpuRequestsMissing: warning

--- a/pkg/kube/resources.go
+++ b/pkg/kube/resources.go
@@ -94,12 +94,16 @@ func (rkm resourceKindMap) GetNumberOfControllers() int {
 	return total
 }
 
+var kindRewrites = map[string]string{
+	"Ingress":                 "networking.k8s.io/Ingress",
+	"PodDisruptionBudget":     "policy/PodDisruptionBudget",
+	"HorizontalPodAutoscaler": "autoscaling/HorizontalPodAutoscaler",
+}
+
 // This is here for backward compatibility reasons
 func maybeTransformKindIntoGroupKind(k string) string {
-	if k == "Ingress" {
-		return "networking.k8s.io/Ingress"
-	} else if k == "PodDisruptionBudget" {
-		return "policy/PodDisruptionBudget"
+	if val, ok := kindRewrites[k]; ok {
+		return val
 	}
 	return k
 }

--- a/pkg/validator/functions.go
+++ b/pkg/validator/functions.go
@@ -1,0 +1,38 @@
+package validator
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/qri-io/jsonschema"
+)
+
+type HorizontalPodAutoscalerView struct {
+	Spec struct {
+		MinReplicas *int `json:"minReplicas"`
+		MaxReplicas int  `json:"maxReplicas"`
+	} `json:"spec"`
+}
+
+func validateHPAMaxAvailability(data any) (bool, []jsonschema.ValError, error) {
+	jsonString, err := json.Marshal(data)
+	if err != nil {
+		return false, nil, err
+	}
+
+	hpa := HorizontalPodAutoscalerView{}
+	err = json.Unmarshal(jsonString, &hpa)
+	if err != nil {
+		return false, nil, err
+	}
+
+	if hpa.Spec.MinReplicas == nil {
+		return true, []jsonschema.ValError{}, nil
+	}
+
+	if hpa.Spec.MaxReplicas > *hpa.Spec.MinReplicas {
+		return true, []jsonschema.ValError{}, nil
+	}
+
+	return false, []jsonschema.ValError{{PropertyPath: "spec.maxReplicas", Message: fmt.Sprintf("maxReplicas (%d) must be greater than minReplicas (%d)", hpa.Spec.MaxReplicas, *hpa.Spec.MinReplicas)}}, nil
+}

--- a/pkg/validator/schema.go
+++ b/pkg/validator/schema.go
@@ -32,14 +32,6 @@ import (
 	"github.com/fairwindsops/polaris/pkg/kube"
 )
 
-type CustomValidator func(data interface{}) (bool, []jsonschema.ValError, error)
-
-// customValidators is a map of validation functions that can be used in schema checks
-// sometimes we need to validate things that aren't covered by the JSON validation schema
-var customValidators = map[string]CustomValidator{
-	"hpaMaxAvailability": validateHPAMaxAvailability,
-}
-
 type schemaTestCase struct {
 	Target           config.TargetKind
 	Resource         kube.GenericResource

--- a/test/checks/hpaMaxAvailability/failure.yaml
+++ b/test/checks/hpaMaxAvailability/failure.yaml
@@ -1,0 +1,30 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: php-apache
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: php-apache
+  minReplicas: 5
+  maxReplicas: 5
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 50
+status:
+  observedGeneration: 1
+  lastScaleTime: "2023-06-26T15:04:05Z"
+  currentReplicas: 1
+  desiredReplicas: 1
+  currentMetrics:
+  - type: Resource
+    resource:
+      name: cpu
+      current:
+        averageUtilization: 0
+        averageValue: 0

--- a/test/checks/hpaMaxAvailability/success.minAvailabilityAbsent.yaml
+++ b/test/checks/hpaMaxAvailability/success.minAvailabilityAbsent.yaml
@@ -1,0 +1,29 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: php-apache
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: php-apache
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 50
+status:
+  observedGeneration: 1
+  lastScaleTime: "2023-06-26T15:04:05Z"
+  currentReplicas: 1
+  desiredReplicas: 1
+  currentMetrics:
+  - type: Resource
+    resource:
+      name: cpu
+      current:
+        averageUtilization: 0
+        averageValue: 0

--- a/test/checks/hpaMaxAvailability/success.yaml
+++ b/test/checks/hpaMaxAvailability/success.yaml
@@ -1,0 +1,30 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: php-apache
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: php-apache
+  minReplicas: 5
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 50
+status:
+  observedGeneration: 1
+  lastScaleTime: "2023-06-26T15:04:05Z"
+  currentReplicas: 1
+  desiredReplicas: 1
+  currentMetrics:
+  - type: Resource
+    resource:
+      name: cpu
+      current:
+        averageUtilization: 0
+        averageValue: 0

--- a/test/checks/hpaMinAvailability/failure.yaml
+++ b/test/checks/hpaMinAvailability/failure.yaml
@@ -1,0 +1,30 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: php-apache
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: php-apache
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 50
+status:
+  observedGeneration: 1
+  lastScaleTime: "2023-06-26T15:04:05Z"
+  currentReplicas: 1
+  desiredReplicas: 1
+  currentMetrics:
+  - type: Resource
+    resource:
+      name: cpu
+      current:
+        averageUtilization: 0
+        averageValue: 0

--- a/test/checks/hpaMinAvailability/success.minReplicaAbsent.yaml
+++ b/test/checks/hpaMinAvailability/success.minReplicaAbsent.yaml
@@ -1,0 +1,29 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: php-apache
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: php-apache
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 50
+status:
+  observedGeneration: 1
+  lastScaleTime: "2023-06-26T15:04:05Z"
+  currentReplicas: 1
+  desiredReplicas: 1
+  currentMetrics:
+  - type: Resource
+    resource:
+      name: cpu
+      current:
+        averageUtilization: 0
+        averageValue: 0

--- a/test/checks/hpaMinAvailability/success.yaml
+++ b/test/checks/hpaMinAvailability/success.yaml
@@ -1,0 +1,30 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: php-apache
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: php-apache
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 50
+status:
+  observedGeneration: 1
+  lastScaleTime: "2023-06-26T15:04:05Z"
+  currentReplicas: 1
+  desiredReplicas: 1
+  currentMetrics:
+  - type: Resource
+    resource:
+      name: cpu
+      current:
+        averageUtilization: 0
+        averageValue: 0

--- a/test/fixtures.go
+++ b/test/fixtures.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingV2 "k8s.io/api/autoscaling/v2"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -225,6 +226,12 @@ func SetupTestAPI(objects ...runtime.Object) (kubernetes.Interface, dynamic.Inte
 			GroupVersion: policyv1.SchemeGroupVersion.String(),
 			APIResources: []metav1.APIResource{
 				{Name: "poddisruptionbudgets", Namespaced: true, Kind: "PodDisruptionBudget", Version: "v1"},
+			},
+		},
+		{
+			GroupVersion: autoscalingV2.SchemeGroupVersion.String(),
+			APIResources: []metav1.APIResource{
+				{Name: "horizontalpodautoscalers", Namespaced: true, Kind: "HorizontalPodAutoscaler", Version: "v2"},
 			},
 		},
 		{

--- a/test/schema_test.go
+++ b/test/schema_test.go
@@ -44,7 +44,7 @@ var mutatedYamlContentMap = map[string]string{}
 var mutationTestCasesMap = map[string][]testCase{}
 
 func init() {
-	checkToTest := os.Getenv("POLARIS_CHECK_TEST")
+	checkToTest := os.Getenv("POLARIS_CHECK_TEST") // if set, only run tests for this check
 	_, baseDir, _, _ := runtime.Caller(0)
 	baseDir = filepath.Dir(baseDir) + "/checks"
 	dirs, err := os.ReadDir(baseDir)
@@ -55,6 +55,9 @@ func init() {
 		check := dir.Name()
 		if checkToTest != "" && checkToTest != check {
 			continue
+		}
+		if strings.HasPrefix(check, "_") {
+			continue // skip directories starting with _
 		}
 		checkDir := baseDir + "/" + check
 		cases, err := os.ReadDir(checkDir)
@@ -119,7 +122,7 @@ func TestChecks(t *testing.T) {
 	for _, tc := range testCases {
 		results, err := validator.ApplyAllSchemaChecksToResourceProvider(&tc.config, tc.resources)
 		if err != nil {
-			panic(err)
+			t.Fatalf("Error running checks: %v", err)
 		}
 		auditData := validator.AuditData{Results: results}
 		summary := auditData.GetSummary()


### PR DESCRIPTION
This PR fixes internal INSIGHTS-90

## Checklist
* [X] I have signed the CLA
* [X] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
- implement support for HPA `minAvailable` check
- implement support for HPA `maxAvailable` check

### What changes did you make?
- I had to implement a custom validator function for validations that are not supported by JSON validation
  - i.e.: in HPA `maxAvailable` check, we need to check fix `maxAvailable` is greater than `minAvailable` and in JSON validation you cannot self-reference fields

### What alternative solution should we consider, if any?

