### PR TITLE
pdbMinAvailableGreaterThanHPAMinReplicas should support optional minAvailable

### DIFF
--- a/pkg/validator/pdb_hpa_validator.go
+++ b/pkg/validator/pdb_hpa_validator.go
@@ -21,7 +21,6 @@ func init() {
 
 func pdbMinAvailableGreaterThanHPAMinReplicas(test schemaTestCase) (bool, []jsonschema.ValError, error) {
 	if test.ResourceProvider == nil {
-		logrus.Debug("ResourceProvider is nil")
 		return true, nil, nil
 	}
 
@@ -47,6 +46,10 @@ func pdbMinAvailableGreaterThanHPAMinReplicas(test schemaTestCase) (bool, []json
 	if attachedPDB != nil && attachedHPA != nil {
 		logrus.Debugf("both PDB and HPA are attached to deployment %s", deployment.Name)
 
+		if attachedPDB.Spec.MinAvailable == nil {
+			return true, nil, nil
+		}
+
 		pdbMinAvailable, isPercent, err := getIntOrPercentValueSafely(attachedPDB.Spec.MinAvailable)
 		if err != nil {
 			logrus.Warnf("error getting getIntOrPercentValueSafely: %v", err)
@@ -56,7 +59,6 @@ func pdbMinAvailableGreaterThanHPAMinReplicas(test schemaTestCase) (bool, []json
 		if isPercent {
 			// if the value is a percentage, we need to calculate the actual value
 			if attachedHPA.Spec.MinReplicas == nil {
-				logrus.Debug("attachedHPA.Spec.MinReplicas is nil")
 				return true, nil, nil
 			}
 
@@ -90,7 +92,6 @@ func hasPDBAttached(deployment appsv1.Deployment, pdbs []kube.GenericResource) (
 		}
 
 		if pdb.Spec.Selector == nil {
-			logrus.Debug("pdb.Spec.Selector is nil")
 			continue
 		}
 

--- a/test/checks/pdbMinAvailableGreaterThanHPAMinReplicas/success-maxUnavailable.yaml
+++ b/test/checks/pdbMinAvailableGreaterThanHPAMinReplicas/success-maxUnavailable.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zookeeper
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: zookeeper
+        foo: bar
+    spec:
+      containers:
+        - name: zookeeper
+          image: zookeeper
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: zookeeper-pdb
+spec:
+  maxUnavailable: 5
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: zookeeper
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: zookeeper-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: zookeeper
+  minReplicas: 5
+  maxReplicas: 7
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50


### PR DESCRIPTION
By spec, `minAvailable` is optional, and we should accommodate for that

This PR fixes #1061

## Checklist
* [X] I have signed the CLA
* [X] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

### What changes did you make?

### What alternative solution should we consider, if any?

