### PR TITLE
Fix: rolebindingRolePodExecAttach check

### DIFF
--- a/pkg/config/checks/rolebindingRolePodExecAttach.yaml
+++ b/pkg/config/checks/rolebindingRolePodExecAttach.yaml
@@ -17,7 +17,7 @@ schemaString: |
               const: "rbac.authorization.k8s.io"
             kind:
               type: string
-              const: "Role"
+              const: "ClusterRole"
     # Do not alert on default RoleBindings.
     - required: ["metadata"]
       properties:

--- a/test/checks/rolebindingRolePodExecAttach/success.role_binding_cluster_role_binding.yaml
+++ b/test/checks/rolebindingRolePodExecAttach/success.role_binding_cluster_role_binding.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: all-operations
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: all-operations
+  namespace: my-namespace
+subjects:
+  - kind: User
+    name: example-user
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: all-operations
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Fix the case of a RoleBinding that points to a ClusterRole.
In that case, we ignore the RoleBinding validation altogether since it will be evaluated by the rolebindingClusterRolePodExecAttach check.


This PR fixes the rolebindingRolePodExecAttach check

## Checklist
* [X] I have signed the CLA
* [X] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

Fix the check of a RoleBinding that references a Role allowing pods/exec or pods/attach in the case that it points to a ClusterRole. 

### What changes did you make?

Modify the kind field value of the roleRef field of the RoleBinding from "Role" to "ClusterRole" in the schemaString

### What alternative solution should we consider, if any?

NA
