### PR TITLE
Fix: rolebindingClusterAdminRole check

### DIFF
--- a/pkg/config/checks/rolebindingClusterAdminRole.yaml
+++ b/pkg/config/checks/rolebindingClusterAdminRole.yaml
@@ -43,10 +43,10 @@ schemaString: |
               minLength: 1
 additionalSchemaStrings:
   rbac.authorization.k8s.io/Role: |
-    type: object
-    # This schema is validated for all roleBindings, regardless of their roleRef.
     {{ if eq .roleRef.kind "Role" }}
     {{ if and (not (hasPrefix .metadata.name "system:")) (ne .metadata.name "gce:podsecuritypolicy:calico-sa") }}
+    # This schema is validated for all roleBindings, regardless of their roleRef.
+    type: object
     required: ["metadata", "rules"]
     allOf:
       - properties:


### PR DESCRIPTION
Fix additionalSchemaStrings templating


This PR fixes the templating of the additionalSchemaStrings in the rolebindingClusterAdminRole check, the if did not include the beginning of the object.

## Checklist
* [X] I have signed the CLA
* [X] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

Fix the rolebindingClusterAdminRole check

### What changes did you make?

Correct the additionalSchemaStrings templating

### What alternative solution should we consider, if any?

NA