### PR TITLE
Add --merge-config flag to support merging with fefault configuration

### DIFF
--- a/cmd/polaris/root.go
+++ b/cmd/polaris/root.go
@@ -24,6 +24,7 @@ import (
 )
 
 var (
+	mergeConfig                  bool
 	configPath                   string
 	disallowExemptions           bool
 	disallowConfigExemptions     bool
@@ -42,6 +43,7 @@ var (
 
 func init() {
 	// Flags
+	rootCmd.PersistentFlags().BoolVarP(&mergeConfig, "merge-config", "m", false, "Custom configuration should be merged with default configuration instead of replacing it.")
 	rootCmd.PersistentFlags().StringVarP(&configPath, "config", "c", "", "Location of Polaris configuration file.")
 	rootCmd.PersistentFlags().StringVarP(&kubeContext, "context", "x", "", "Set the kube context.")
 	rootCmd.PersistentFlags().BoolVarP(&disallowExemptions, "disallow-exemptions", "", false, "Disallow any configured exemption.")
@@ -65,7 +67,7 @@ var rootCmd = &cobra.Command{
 			logrus.SetLevel(parsedLevel)
 		}
 
-		config, err = conf.ParseFile(configPath)
+		config, err = conf.MergeConfigAndParseFile(configPath, mergeConfig)
 		if err != nil {
 			logrus.Errorf("Error parsing config at %s: %v", configPath, err)
 			os.Exit(1)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -125,7 +125,7 @@ func TestConfigFromURL(t *testing.T) {
 	}()
 	time.Sleep(time.Second)
 
-	parsedConf, err = ParseFile("http://localhost:8081/exampleURL")
+	parsedConf, err = MergeConfigAndParseFile("http://localhost:8081/exampleURL", false)
 	assert.NoError(t, err, "Expected no error when parsing YAML from URL")
 	if err := srv.Shutdown(context.TODO()); err != nil {
 		panic(err)
@@ -136,7 +136,7 @@ func TestConfigFromURL(t *testing.T) {
 
 func TestConfigNoServerError(t *testing.T) {
 	var err error
-	_, err = ParseFile("http://localhost:8081/exampleURL")
+	_, err = MergeConfigAndParseFile("http://localhost:8081/exampleURL", false)
 	assert.Error(t, err)
 	assert.Regexp(t, regexp.MustCompile("connection refused"), err.Error())
 }

--- a/pkg/config/merger.go
+++ b/pkg/config/merger.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	"gopkg.in/yaml.v3" // do not change the yaml import
+)
+
+func mergeYaml(defaultConfig, overridesConfig []byte) ([]byte, error) {
+	var defaultData, overrideConfig map[string]any
+
+	err := yaml.Unmarshal([]byte(defaultConfig), &defaultData)
+	if err != nil {
+		return nil, err
+	}
+
+	err = yaml.Unmarshal([]byte(overridesConfig), &overrideConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	mergedData := mergeYAMLMaps(defaultData, overrideConfig)
+
+	mergedConfig, err := yaml.Marshal(mergedData)
+	if err != nil {
+		return nil, err
+	}
+
+	return mergedConfig, nil
+}
+
+func mergeYAMLMaps(defaults, overrides map[string]any) map[string]any {
+	for k, v := range overrides {
+		if vMap, ok := v.(map[string]any); ok {
+			// if the key exists in defaults and is a map, recursively merge
+			if mv1, ok := defaults[k].(map[string]any); ok {
+				defaults[k] = mergeYAMLMaps(mv1, vMap)
+			} else {
+				defaults[k] = vMap
+			}
+		} else {
+			// add or overwrite the value in defaults
+			defaults[k] = v
+		}
+	}
+	return defaults
+}

--- a/pkg/config/merger_test.go
+++ b/pkg/config/merger_test.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var defaults = `
+checks:
+    deploymentMissingReplicas: warning
+    priorityClassNotSet: warning
+    tagNotSpecified: danger
+existing:
+    sub:
+      key: value
+`
+
+var overrides = `
+checks:
+    pullPolicyNotAlways: ignore
+    tagNotSpecified: overrides
+existing:
+    sub:
+      key1: value1
+    new: value
+new:
+    key: value
+`
+
+func TestMergeYaml(t *testing.T) {
+	mergedContent, err := mergeYaml([]byte(defaults), []byte(overrides))
+	assert.NoError(t, err)
+
+	expectedYAML := `checks:
+    deploymentMissingReplicas: warning
+    priorityClassNotSet: warning
+    pullPolicyNotAlways: ignore
+    tagNotSpecified: overrides
+existing:
+    new: value
+    sub:
+        key: value
+        key1: value1
+new:
+    key: value
+`
+
+	assert.Equal(t, expectedYAML, string(mergedContent))
+}


### PR DESCRIPTION
This PR fixes #910

## Checklist
* [X] I have signed the CLA
* [X] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
This PR introduces a new Polaris flag, `--merge-config` (`-m`), which allows merging user-provided configurations with the default settings, instead of fully overriding them. This provides greater flexibility by retaining default values for unspecified settings, ensuring smoother configuration management.

### What changes did you make?
- added new parameter
- `ParseFile` function is now `MergeConfigAndParseFile`

### What alternative solution should we consider, if any?

