### PR TITLE
Fixes the Polaris download URL

### DIFF
--- a/.github/actions/setup-polaris/get_polaris.sh
+++ b/.github/actions/setup-polaris/get_polaris.sh
@@ -3,7 +3,7 @@ if [[ -z "$INPUT_VERSION" ]]; then
   echo "Missing polaris version information"
   exit 1
 fi
-POLARIS_URL=https://github.com/FairwindsOps/polaris/releases/download/$INPUT_VERSION/polaris_linux_amd64.tar.gz
+POLARIS_URL=https://github.com/FairwindsOps/polaris/releases/download/$INPUT_VERSION/polaris_$(echo -n $INPUT_VERSION | tr -d "v")_linux_amd64.tar.gz
 polaris version | grep "$INPUT_VERSION" &> /dev/null
 if [ $? == 0 ]; then
    echo "Polaris $INPUT_VERSION is already installed! Exiting gracefully."


### PR DESCRIPTION
This PR fixes #1199

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
The goal of this PR is to fix a bug in `get_polaris.sh` where the script fails to download the Polaris binary for recent releases due to a mismatch in the release asset naming convention.

### What changes did you make?
I updated the `POLARIS_URL` construction inside `get_polaris.sh`. It now dynamically strips the "v" prefix from the `$INPUT_VERSION` variable using `tr -d "v"` specifically for the asset filename part of the URL, while keeping the full tag for the download path.

### What alternative solution should we consider, if any?
None. This is the most straightforward and lightweight way to handle the version string adjustment directly inside the Bash script without adding external dependencies.
