### PR TITLE
Add SARIF output format for audit results

### DIFF
--- a/cmd/polaris/audit.go
+++ b/cmd/polaris/audit.go
@@ -59,7 +59,7 @@ func init() {
 	auditCmd.PersistentFlags().IntVar(&minScore, "set-exit-code-below-score", 0, "Set an exit code of 4 when the score is below this threshold (1-100).")
 	auditCmd.PersistentFlags().StringVar(&auditOutputURL, "output-url", "", "Destination URL to send audit results.")
 	auditCmd.PersistentFlags().StringVar(&auditOutputFile, "output-file", "", "Destination file for audit results.")
-	auditCmd.PersistentFlags().StringVarP(&auditOutputFormat, "format", "f", "json", "Output format for results - json, yaml, pretty, or score.")
+	auditCmd.PersistentFlags().StringVarP(&auditOutputFormat, "format", "f", "json", "Output format for results - json, yaml, pretty, sarif, or score.")
 	auditCmd.PersistentFlags().BoolVar(&useColor, "color", true, "Whether to use color in pretty format.")
 	auditCmd.PersistentFlags().StringVar(&displayName, "display-name", "", "An optional identifier for the audit.")
 	auditCmd.PersistentFlags().StringVar(&resourceToAudit, "resource", "", "Audit a specific resource, in the format namespace/kind/version/name, e.g. nginx-ingress/Deployment.apps/v1/default-backend.")
@@ -199,6 +199,8 @@ func outputAudit(auditData validator.AuditData, outputFile, outputURL, outputFor
 		}
 	} else if outputFormat == "pretty" {
 		outputBytes = []byte(auditData.GetPrettyOutput(useColor))
+	} else if outputFormat == "sarif" {
+		outputBytes, err = auditData.GetSarifOutput()
 	} else {
 		outputBytes, err = json.MarshalIndent(auditData, "", "  ")
 	}
@@ -221,6 +223,8 @@ func outputAudit(auditData validator.AuditData, outputFile, outputURL, outputFor
 				req.Header.Set("Content-Type", "application/json")
 			} else if outputFormat == "yaml" {
 				req.Header.Set("Content-Type", "application/x-yaml")
+			} else if outputFormat == "sarif" {
+				req.Header.Set("Content-Type", "application/sarif+json")
 			} else {
 				req.Header.Set("Content-Type", "text/plain")
 			}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -44,7 +44,7 @@ webhook
     --checks strings                  Optional flag to specify specific checks to check
     --color                           Whether to use color in pretty format. (default true)
     --display-name string             An optional identifier for the audit.
--f, --format string                   Output format for results - json, yaml, pretty, or score. (default "json")
+-f, --format string                   Output format for results - json, yaml, pretty, sarif, or score. (default "json")
     --helm-chart string               Will fill out Helm template
     --helm-values string              Optional flag to add helm values
     --helm-skip-tests bool            Corresponds to --skip-tests of helm template

--- a/pkg/validator/sarif.go
+++ b/pkg/validator/sarif.go
@@ -1,0 +1,191 @@
+// Copyright 2026 FairwindsOps Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/fairwindsops/polaris/pkg/config"
+)
+
+const (
+	sarifVersion        = "2.1.0"
+	sarifSchema         = "https://json.schemastore.org/sarif-2.1.0.json"
+	sarifToolName       = "Polaris"
+	sarifInformationURI = "https://github.com/FairwindsOps/polaris"
+)
+
+// sarifReport is the top-level SARIF 2.1.0 document.
+// See https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html
+type sarifReport struct {
+	Schema  string     `json:"$schema"`
+	Version string     `json:"version"`
+	Runs    []sarifRun `json:"runs"`
+}
+
+type sarifRun struct {
+	Tool    sarifTool     `json:"tool"`
+	Results []sarifResult `json:"results"`
+}
+
+type sarifTool struct {
+	Driver sarifDriver `json:"driver"`
+}
+
+type sarifDriver struct {
+	Name           string      `json:"name"`
+	InformationURI string      `json:"informationUri"`
+	Rules          []sarifRule `json:"rules"`
+}
+
+type sarifRule struct {
+	ID               string               `json:"id"`
+	Name             string               `json:"name,omitempty"`
+	ShortDescription sarifMessage         `json:"shortDescription"`
+	Properties       *sarifRuleProperties `json:"properties,omitempty"`
+}
+
+type sarifRuleProperties struct {
+	Category string `json:"category,omitempty"`
+}
+
+type sarifResult struct {
+	RuleID    string          `json:"ruleId"`
+	Level     string          `json:"level"`
+	Message   sarifMessage    `json:"message"`
+	Locations []sarifLocation `json:"locations,omitempty"`
+}
+
+type sarifMessage struct {
+	Text string `json:"text"`
+}
+
+type sarifLocation struct {
+	LogicalLocations []sarifLogicalLocation `json:"logicalLocations,omitempty"`
+}
+
+type sarifLogicalLocation struct {
+	FullyQualifiedName string `json:"fullyQualifiedName"`
+	Kind               string `json:"kind,omitempty"`
+}
+
+// sarifLevel maps a Polaris severity to a SARIF result level.
+func sarifLevel(severity config.Severity) string {
+	switch severity {
+	case config.SeverityDanger:
+		return "error"
+	case config.SeverityWarning:
+		return "warning"
+	case config.SeverityIgnore:
+		return "note"
+	default:
+		return "none"
+	}
+}
+
+// resourceLocation builds a SARIF logical-location name for a Kubernetes resource.
+func resourceLocation(namespace, kind, name string) string {
+	if namespace != "" {
+		return fmt.Sprintf("%s/%s/%s", namespace, kind, name)
+	}
+	return fmt.Sprintf("%s/%s", kind, name)
+}
+
+// GetSarifOutput returns the audit results encoded as a SARIF 2.1.0 report.
+//
+// Following SARIF's finding-oriented semantics, only failed checks are emitted
+// as results. Each result carries a logical location identifying the Kubernetes
+// resource (and container, when the check applies to one).
+func (res AuditData) GetSarifOutput() ([]byte, error) {
+	rules := map[string]sarifRule{}
+	results := []sarifResult{}
+
+	addMessages := func(messages ResultSet, location string) {
+		for _, msg := range messages {
+			if msg.Success {
+				continue
+			}
+			if _, ok := rules[msg.ID]; !ok {
+				rule := sarifRule{
+					ID:               msg.ID,
+					Name:             msg.ID,
+					ShortDescription: sarifMessage{Text: msg.Message},
+				}
+				if msg.Category != "" {
+					rule.Properties = &sarifRuleProperties{Category: msg.Category}
+				}
+				rules[msg.ID] = rule
+			}
+			results = append(results, sarifResult{
+				RuleID:  msg.ID,
+				Level:   sarifLevel(msg.Severity),
+				Message: sarifMessage{Text: msg.Message},
+				Locations: []sarifLocation{{
+					LogicalLocations: []sarifLogicalLocation{{
+						FullyQualifiedName: location,
+						Kind:               "resource",
+					}},
+				}},
+			})
+		}
+	}
+
+	for _, result := range res.Results {
+		base := resourceLocation(result.Namespace, result.Kind, result.Name)
+		addMessages(result.Results, base)
+		if result.PodResult != nil {
+			addMessages(result.PodResult.Results, base)
+			for _, cr := range result.PodResult.ContainerResults {
+				addMessages(cr.Results, base+"/container/"+cr.Name)
+			}
+		}
+	}
+
+	// Sort results for deterministic output, since the audit may visit
+	// resources in a non-deterministic (map) order.
+	sort.SliceStable(results, func(i, j int) bool {
+		if results[i].RuleID != results[j].RuleID {
+			return results[i].RuleID < results[j].RuleID
+		}
+		li := results[i].Locations[0].LogicalLocations[0].FullyQualifiedName
+		lj := results[j].Locations[0].LogicalLocations[0].FullyQualifiedName
+		if li != lj {
+			return li < lj
+		}
+		return results[i].Message.Text < results[j].Message.Text
+	})
+
+	ruleList := make([]sarifRule, 0, len(rules))
+	for _, rule := range rules {
+		ruleList = append(ruleList, rule)
+	}
+	sort.Slice(ruleList, func(i, j int) bool { return ruleList[i].ID < ruleList[j].ID })
+
+	report := sarifReport{
+		Schema:  sarifSchema,
+		Version: sarifVersion,
+		Runs: []sarifRun{{
+			Tool: sarifTool{Driver: sarifDriver{
+				Name:           sarifToolName,
+				InformationURI: sarifInformationURI,
+				Rules:          ruleList,
+			}},
+			Results: results,
+		}},
+	}
+	return json.MarshalIndent(report, "", "  ")
+}

--- a/pkg/validator/sarif_test.go
+++ b/pkg/validator/sarif_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 FairwindsOps Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/fairwindsops/polaris/pkg/config"
+)
+
+func TestGetSarifOutput(t *testing.T) {
+	auditData := AuditData{
+		Results: []Result{
+			{
+				Name:      "test-deployment",
+				Namespace: "default",
+				Kind:      "Deployment",
+				Results: ResultSet{
+					"deploymentMissingReplicas": ResultMessage{
+						ID:       "deploymentMissingReplicas",
+						Message:  "Should have multiple replicas",
+						Success:  false,
+						Severity: config.SeverityDanger,
+						Category: "Reliability",
+					},
+					"passingCheck": ResultMessage{
+						ID:       "passingCheck",
+						Message:  "This passed",
+						Success:  true,
+						Severity: config.SeverityWarning,
+						Category: "Reliability",
+					},
+				},
+				PodResult: &PodResult{
+					Name: "test-deployment",
+					ContainerResults: []ContainerResult{
+						{
+							Name: "nginx",
+							Results: ResultSet{
+								"runAsNonRoot": ResultMessage{
+									ID:       "runAsNonRoot",
+									Message:  "Should not be allowed to run as root",
+									Success:  false,
+									Severity: config.SeverityWarning,
+									Category: "Security",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	out, err := auditData.GetSarifOutput()
+	assert.NoError(t, err)
+
+	var report sarifReport
+	assert.NoError(t, json.Unmarshal(out, &report))
+
+	assert.Equal(t, "2.1.0", report.Version)
+	assert.Equal(t, sarifSchema, report.Schema)
+	assert.Len(t, report.Runs, 1)
+
+	run := report.Runs[0]
+	assert.Equal(t, "Polaris", run.Tool.Driver.Name)
+
+	// Only the two failed checks are emitted; the passing check is skipped.
+	assert.Len(t, run.Results, 2)
+	assert.Len(t, run.Tool.Driver.Rules, 2)
+
+	// Results are emitted in a deterministic order (ruleId, then location).
+	assert.Equal(t, []string{"deploymentMissingReplicas", "runAsNonRoot"},
+		[]string{run.Results[0].RuleID, run.Results[1].RuleID})
+
+	byRule := map[string]sarifResult{}
+	for _, r := range run.Results {
+		byRule[r.RuleID] = r
+	}
+
+	danger, ok := byRule["deploymentMissingReplicas"]
+	assert.True(t, ok)
+	assert.Equal(t, "error", danger.Level)
+	assert.Equal(t, "Should have multiple replicas", danger.Message.Text)
+	assert.Equal(t, "default/Deployment/test-deployment", danger.Locations[0].LogicalLocations[0].FullyQualifiedName)
+
+	warning, ok := byRule["runAsNonRoot"]
+	assert.True(t, ok)
+	assert.Equal(t, "warning", warning.Level)
+	assert.Equal(t, "default/Deployment/test-deployment/container/nginx", warning.Locations[0].LogicalLocations[0].FullyQualifiedName)
+
+	_, passing := byRule["passingCheck"]
+	assert.False(t, passing)
+}
+
+func TestGetSarifOutputEmpty(t *testing.T) {
+	out, err := AuditData{}.GetSarifOutput()
+	assert.NoError(t, err)
+
+	var report sarifReport
+	assert.NoError(t, json.Unmarshal(out, &report))
+	assert.Equal(t, "2.1.0", report.Version)
+	assert.Len(t, report.Runs, 1)
+	assert.Empty(t, report.Runs[0].Results)
+	assert.Empty(t, report.Runs[0].Tool.Driver.Rules)
+	// results must serialize as an empty array, not null.
+	assert.Contains(t, string(out), `"results": []`)
+	assert.NotContains(t, string(out), `"results": null`)
+}
+
+func TestSarifLevel(t *testing.T) {
+	assert.Equal(t, "error", sarifLevel(config.SeverityDanger))
+	assert.Equal(t, "warning", sarifLevel(config.SeverityWarning))
+	assert.Equal(t, "note", sarifLevel(config.SeverityIgnore))
+	assert.Equal(t, "none", sarifLevel(config.Severity("bogus")))
+}


### PR DESCRIPTION
This PR fixes #857

## Checklist
* [ ] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description

### What's the goal of this PR?

Add a `sarif` output format to `polaris audit`, so audit results can be consumed by tooling that understands SARIF 2.1.0 (GitHub code scanning, IDE SARIF viewers, etc.). Requested in #857.

### What changes did you make?

- Added `pkg/validator/sarif.go` with a `GetSarifOutput()` method on `AuditData` that encodes results as a SARIF 2.1.0 report. The document is built from plain structs (no new dependency).
- Wired `--format sarif` into `outputAudit()` in `cmd/polaris/audit.go`, updated the `--format` help text, and set the `application/sarif+json` Content-Type when posting to `--output-url`.
- Documented the new format in `docs/cli.md`.
- Added unit tests in `pkg/validator/sarif_test.go`.

Behavior notes:
- Only **failed** checks are emitted as SARIF results, following SARIF's finding-oriented semantics. Severity maps `danger → error`, `warning → warning`, `ignore → note`.
- Each result carries a logical location identifying the resource (`<namespace>/<Kind>/<name>`, plus `/container/<name>` for container checks).
- Output is deterministic (rules and results are sorted), so it stays diff-friendly.

Validation:
- `gofmt` and `go vet ./...` clean
- `go test ./pkg/validator/` passes (new SARIF tests + existing suite)
- End-to-end: `polaris audit --audit-path <manifest> --format sarif` produces valid SARIF 2.1.0 (20 rules / 20 results on a sample Deployment), byte-identical across repeated runs.

### What alternative solution should we consider, if any?

- A SARIF library (e.g. `owenrumney/go-sarif`) could replace the hand-rolled structs; I kept it dependency-free for a smaller surface, but happy to switch if you prefer.
- Physical locations (file + region) could be added when auditing via `--audit-path`; this PR uses logical locations so cluster audits and file audits behave consistently. Glad to extend if useful.