### PR TITLE
Validate ephemeral containers in per-container checks

### DIFF
--- a/pkg/validator/schema.go
+++ b/pkg/validator/schema.go
@@ -278,6 +278,18 @@ func applyControllerSchemaChecks(ctx context.Context, conf *config.Configuration
 		}
 		podRes.ContainerResults = append(podRes.ContainerResults, cRes)
 	}
+	for _, ec := range resource.PodSpec.EphemeralContainers {
+		container := corev1.Container(ec.EphemeralContainerCommon)
+		results, err := applyContainerSchemaChecks(ctx, conf, resourceProvider, resource, &container, false)
+		if err != nil {
+			return finalResult, err
+		}
+		cRes := ContainerResult{
+			Name:    container.Name,
+			Results: results,
+		}
+		podRes.ContainerResults = append(podRes.ContainerResults, cRes)
+	}
 
 	return finalResult, nil
 }

--- a/pkg/validator/schema_test.go
+++ b/pkg/validator/schema_test.go
@@ -19,10 +19,12 @@ import (
 	"testing"
 
 	conf "github.com/fairwindsops/polaris/pkg/config"
+	"github.com/fairwindsops/polaris/pkg/kube"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var customCheckExemptions = `
@@ -275,4 +277,35 @@ func TestValidateCustomCheckExemptions(t *testing.T) {
 		},
 	}
 	testValidate(t, &container, &customCheckExemptions, "notexempt", expectedDangers, expectedWarnings, expectedSuccesses)
+}
+
+var resourceConfEphemeral = `
+checks:
+  runAsRootAllowed: danger
+`
+
+func TestEphemeralContainersAreChecked(t *testing.T) {
+	parsed, err := conf.Parse([]byte(resourceConfEphemeral))
+	assert.NoError(t, err)
+
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "app"}},
+			EphemeralContainers: []corev1.EphemeralContainer{{
+				EphemeralContainerCommon: corev1.EphemeralContainerCommon{Name: "debugger"},
+			}},
+		},
+	}
+	workload, err := kube.NewGenericResourceFromPod(pod, nil)
+	assert.NoError(t, err)
+
+	result, err := ApplyAllSchemaChecks(context.Background(), &parsed, nil, workload)
+	assert.NoError(t, err)
+
+	names := map[string]bool{}
+	for _, cr := range result.PodResult.ContainerResults {
+		names[cr.Name] = true
+	}
+	assert.True(t, names["debugger"], "ephemeral container should be checked")
 }


### PR DESCRIPTION
This PR fixes #1203

## Checklist

* [ ] I have signed the CLA
* [ ] I have updated/added any relevant documentation

## Description

### What's the goal of this PR?

Run the per-container checks against ephemeral containers. Today they only cover init and regular containers, so a privileged ephemeral container passes every container-level check.

### What changes did you make?

Added an `EphemeralContainers` loop in `applyControllerSchemaChecks` (`pkg/validator/schema.go`) alongside the init and regular container loops. `EphemeralContainer.EphemeralContainerCommon` converts to `corev1.Container`, so it reuses `applyContainerSchemaChecks`. Added a test that a privileged ephemeral container is now evaluated.

### What alternative solution should we consider, if any?

None.
