### PR TITLE
fix(setup-polaris): include version in release asset filename

### DIFF
--- a/.github/actions/setup-polaris/get_polaris.sh
+++ b/.github/actions/setup-polaris/get_polaris.sh
@@ -3,7 +3,8 @@ if [[ -z "$INPUT_VERSION" ]]; then
   echo "Missing polaris version information"
   exit 1
 fi
-POLARIS_URL=https://github.com/FairwindsOps/polaris/releases/download/$INPUT_VERSION/polaris_linux_amd64.tar.gz
+ASSET_VERSION=${INPUT_VERSION#v}
+POLARIS_URL=https://github.com/FairwindsOps/polaris/releases/download/$INPUT_VERSION/polaris_${ASSET_VERSION}_linux_amd64.tar.gz
 polaris version | grep "$INPUT_VERSION" &> /dev/null
 if [ $? == 0 ]; then
    echo "Polaris $INPUT_VERSION is already installed! Exiting gracefully."


### PR DESCRIPTION
Release assets are named polaris_<version>_linux_amd64.tar.gz but the setup action fetched polaris_linux_amd64.tar.gz, so every run 404s and the tarball extraction fails. The URL now embeds the version, stripping only a leading v so both v10.2.0 and 10.2.0 inputs resolve to the published asset.