### PR TITLE
Guard pod-spec type assertions against non-map manifest fields

### DIFF
--- a/pkg/kube/resource.go
+++ b/pkg/kube/resource.go
@@ -266,7 +266,9 @@ func GetObject(ctx context.Context, namespace, kind, version, name string, dynam
 func GetPodSpec(yaml map[string]any) any {
 	for _, child := range podSpecFields {
 		if childYaml, ok := yaml[child]; ok {
-			return GetPodSpec(childYaml.(map[string]any))
+			if childYamlMap, ok := childYaml.(map[string]any); ok {
+				return GetPodSpec(childYamlMap)
+			}
 		}
 	}
 	if _, ok := yaml["containers"]; ok {
@@ -300,7 +302,9 @@ func GetPodTemplate(yaml map[string]any) (podTemplate any, err error) {
 	}
 	for _, podSpecField := range podSpecFields {
 		if childYaml, ok := yaml[podSpecField]; ok {
-			return GetPodTemplate(childYaml.(map[string]any))
+			if childYamlMap, ok := childYaml.(map[string]any); ok {
+				return GetPodTemplate(childYamlMap)
+			}
 		}
 	}
 	return nil, nil

--- a/pkg/kube/resources_test.go
+++ b/pkg/kube/resources_test.go
@@ -176,3 +176,26 @@ func TestGetResourceFromAPI(t *testing.T) {
 		})
 	}
 }
+
+// A malformed manifest can have a field like `spec` that is a scalar instead
+// of a map. GetPodSpec and GetPodTemplate walk those fields recursively, so a
+// non-map value there must not panic the scan.
+func TestGetPodSpecNonMapField(t *testing.T) {
+	malformed := map[string]any{
+		"spec": "not-a-map",
+	}
+
+	var spec any
+	assert.NotPanics(t, func() {
+		spec = GetPodSpec(malformed)
+	}, "GetPodSpec should not panic on a non-map spec")
+	assert.Nil(t, spec, "GetPodSpec should return nil when no pod spec is found")
+
+	var template any
+	var err error
+	assert.NotPanics(t, func() {
+		template, err = GetPodTemplate(malformed)
+	}, "GetPodTemplate should not panic on a non-map spec")
+	assert.NoError(t, err)
+	assert.Nil(t, template, "GetPodTemplate should return nil when no pod template is found")
+}


### PR DESCRIPTION
This PR fixes #

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

Keep a scan from panicking on a malformed manifest. `GetPodSpec` and `GetPodTemplate` walk `podSpecFields` (`jobTemplate`, `spec`, `template`) recursively and do an unchecked `childYaml.(map[string]any)` assertion on each. If one of those fields is a scalar instead of a map, the assertion panics and takes down the whole scan.

Reproduced with a manifest whose `spec` is a string. Before the fix the panic surfaces at `pkg/kube/resource.go:269`:

```
interface conversion: interface {} is string, not map[string]interface {}
        /tmp/polaris/pkg/kube/resource.go:269
```

### What changes did you make?

Switched the two assertions (in `GetPodSpec` and `GetPodTemplate`) to the comma-ok form, so a non-map value is skipped and the walk returns cleanly with no pod spec / template found. This matches the guard already used for the `spec` map a few lines up in `GetPodTemplate` (`if yamlSpecMap, ok := yamlSpec.(map[string]any); ok`).

Added `TestGetPodSpecNonMapField`, which feeds a manifest with a scalar `spec` and asserts neither function panics and both return nil. With the fix reverted the test panics as above; with it in place `go test ./pkg/kube/` passes.

### What alternative solution should we consider, if any?

Could validate/normalize the manifest shape earlier in the pipeline, but guarding the assertions here is the smaller change and lines up with the existing comma-ok pattern in the same function.
