### PR TITLE
Allow custom docURL for check documentation links

### DIFF
--- a/docs/customization/custom-checks.md
+++ b/docs/customization/custom-checks.md
@@ -40,7 +40,8 @@ check ID. Note that you'll also have to set its severity in the `checks` section
 
 * `successMessage` - the message to show when the check succeeds
 * `failureMessage` - the message to show when the check fails
-* `category` - one of `Security`, `Efficiency`, or `Reliability`
+* `category` - `Security`, `Efficiency`, `Reliability`, or a custom category name of your own
+* `docURL` - optional link to documentation for the check. When set, the dashboard uses it for the check's "more info" link instead of the default Fairwinds docs URL. Handy for custom categories that don't have a page on the Fairwinds docs site.
 * `target` - specifies the type of resource to check. This can be:
   * a group and kind, e.g. `apps/Deployment` or `networking.k8s.io/Ingress`
   * `Controller`, to check _any_ resource that creates Pods (e.g. Deployments, CronJobs, StatefulSets), as well as naked Pods

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -68,6 +68,7 @@ type Mutation struct {
 type SchemaCheck struct {
 	ID                      string                       `yaml:"id" json:"id"`
 	Category                string                       `yaml:"category" json:"category"`
+	DocumentationURL        string                       `yaml:"docURL" json:"docURL"`
 	SuccessMessage          string                       `yaml:"successMessage" json:"successMessage"`
 	FailureMessage          string                       `yaml:"failureMessage" json:"failureMessage"`
 	Controllers             includeExcludeList           `yaml:"controllers" json:"controllers"`

--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -67,15 +67,17 @@ type templateData struct {
 // GetBaseTemplate puts together the dashboard template. Individual pieces can be overridden before rendering.
 func GetBaseTemplate(name string) (*template.Template, error) {
 	tmpl := template.New(name).Funcs(template.FuncMap{
-		"getWarningWidth": getWarningWidth,
-		"getSuccessWidth": getSuccessWidth,
-		"getWeatherIcon":  getWeatherIcon,
-		"getWeatherText":  getWeatherText,
-		"getGrade":        getGrade,
-		"getIcon":         getIcon,
-		"getResultClass":  getResultClass,
-		"getCategoryLink": getCategoryLink,
-		"getCategoryInfo": getCategoryInfo,
+		"getWarningWidth":              getWarningWidth,
+		"getSuccessWidth":              getSuccessWidth,
+		"getWeatherIcon":               getWeatherIcon,
+		"getWeatherText":               getWeatherText,
+		"getGrade":                     getGrade,
+		"getIcon":                      getIcon,
+		"getResultClass":               getResultClass,
+		"getCategoryLink":              getCategoryLink,
+		"getResultDocumentationLink":   getResultDocumentationLink,
+		"getCategoryDocumentationLink": getCategoryDocumentationLink,
+		"getCategoryInfo":              getCategoryInfo,
 	})
 
 	templateFileNames := []string{

--- a/pkg/dashboard/helpers.go
+++ b/pkg/dashboard/helpers.go
@@ -126,6 +126,26 @@ func getCategoryLink(category string) string {
 	return "https://polaris.docs.fairwinds.com/checks/" + strings.ToLower(category)
 }
 
+// getResultDocumentationLink returns the docURL configured on a check when set,
+// otherwise the default Fairwinds docs link for the check's category.
+func getResultDocumentationLink(rm validator.ResultMessage) string {
+	if rm.DocumentationURL != "" {
+		return rm.DocumentationURL
+	}
+	return getCategoryLink(rm.Category)
+}
+
+// getCategoryDocumentationLink returns the docURL configured on any custom check
+// in the category, otherwise the default Fairwinds docs link for that category.
+func getCategoryDocumentationLink(conf config.Configuration, category string) string {
+	for _, check := range conf.CustomChecks {
+		if check.Category == category && check.DocumentationURL != "" {
+			return check.DocumentationURL
+		}
+	}
+	return getCategoryLink(category)
+}
+
 func getCategoryInfo(category string) string {
 	switch category {
 	case "Reliability":

--- a/pkg/dashboard/helpers_test.go
+++ b/pkg/dashboard/helpers_test.go
@@ -203,6 +203,34 @@ func TestGetCategoryLink(t *testing.T) {
 	assert.NotEqual(t, "ttps://polaris.docs.fairwinds.com/checks/reliability", actual)
 }
 
+func TestGetResultDocumentationLink(t *testing.T) {
+	// custom docURL wins when set
+	custom := validator.ResultMessage{Category: "Business", DocumentationURL: "https://docs.example.com/business"}
+	assert.Equal(t, "https://docs.example.com/business", getResultDocumentationLink(custom))
+
+	// falls back to the Fairwinds category link when unset
+	fallback := validator.ResultMessage{Category: "Efficiency"}
+	assert.Equal(t, "https://polaris.docs.fairwinds.com/checks/efficiency", getResultDocumentationLink(fallback))
+}
+
+func TestGetCategoryDocumentationLink(t *testing.T) {
+	conf := config.Configuration{
+		CustomChecks: map[string]config.SchemaCheck{
+			"customBusinessCheck": {Category: "Business", DocumentationURL: "https://docs.example.com/business"},
+			"customPlainCheck":    {Category: "Compliance"},
+		},
+	}
+
+	// a custom check in the category carries the docURL through
+	assert.Equal(t, "https://docs.example.com/business", getCategoryDocumentationLink(conf, "Business"))
+
+	// no docURL on any check in the category -> default link
+	assert.Equal(t, "https://polaris.docs.fairwinds.com/checks/compliance", getCategoryDocumentationLink(conf, "Compliance"))
+
+	// category with no matching custom check -> default link
+	assert.Equal(t, "https://polaris.docs.fairwinds.com/checks/security", getCategoryDocumentationLink(conf, "Security"))
+}
+
 func TestGetCategoryInfo(t *testing.T) {
 	input := "Security"
 

--- a/pkg/dashboard/templates/dashboard.gohtml
+++ b/pkg/dashboard/templates/dashboard.gohtml
@@ -107,7 +107,7 @@
           </div>
           <div class="name"><span class="caret-expander"></span>{{ $category }}<span class="category-score">Score: <strong>{{ $summary.GetScore }}%</strong></span></div>
           <div class="result-messages expandable-content">
-            <p class="category-info">{{ getCategoryInfo $category }} Refer to the <a href="{{ getCategoryLink $category }}" target="_blank">Polaris documentation about {{ $category }}</a> for more information.</p>
+            <p class="category-info">{{ getCategoryInfo $category }} Refer to the <a href="{{ getCategoryDocumentationLink $.Config $category }}" target="_blank">Polaris documentation about {{ $category }}</a> for more information.</p>
           </div>
         </div>
       {{ end }} {{/* end range categories */}}
@@ -169,7 +169,7 @@
                     <li class="{{ getResultClass . }}">
                       <i class="message-icon {{ getIcon $message }}"></i>
                       <span class="message">{{ .Message }}</span>
-                      <a class="more-info" href="{{ getCategoryLink .Category }}" target="_blank">
+                      <a class="more-info" href="{{ getResultDocumentationLink . }}" target="_blank">
                         <i class="far fa-question-circle"></i>
                       </a>
                     </li>
@@ -189,7 +189,7 @@
                       <li class="{{ getResultClass . }}">
                         <i class="message-icon {{ getIcon $message }}"></i>
                         <span class="message">{{ .Message }}</span>
-                        <a class="more-info" href="{{ getCategoryLink .Category }}" target="_blank">
+                        <a class="more-info" href="{{ getResultDocumentationLink . }}" target="_blank">
                           <i class="far fa-question-circle"></i>
                         </a>
                       </li>
@@ -211,7 +211,7 @@
                         <li class="{{ getResultClass . }}">
                           <i class="message-icon {{ getIcon $message }}"></i>
                           <span class="message">{{ .Message }}</span>
-                          <a class="more-info" href="{{ getCategoryLink .Category }}" target="_blank">
+                          <a class="more-info" href="{{ getResultDocumentationLink . }}" target="_blank">
                             <i class="far fa-question-circle"></i>
                           </a>
                         </li>

--- a/pkg/validator/output.go
+++ b/pkg/validator/output.go
@@ -102,13 +102,14 @@ type ClusterInfo struct {
 
 // ResultMessage is the result of a given check
 type ResultMessage struct {
-	ID        string
-	Message   string
-	Details   []string
-	Success   bool
-	Severity  config.Severity
-	Category  string
-	Mutations []config.Mutation
+	ID               string
+	Message          string
+	Details          []string
+	Success          bool
+	Severity         config.Severity
+	Category         string
+	DocumentationURL string
+	Mutations        []config.Mutation
 }
 
 // ResultSet contiains the results for a set of checks

--- a/pkg/validator/schema.go
+++ b/pkg/validator/schema.go
@@ -141,10 +141,11 @@ func makeResult(conf *config.Configuration, check *config.SchemaCheck, passes bo
 		details = append(details, issue.Message)
 	}
 	result := ResultMessage{
-		ID:       check.ID,
-		Severity: conf.Checks[check.ID],
-		Category: check.Category,
-		Success:  passes,
+		ID:               check.ID,
+		Severity:         conf.Checks[check.ID],
+		Category:         check.Category,
+		DocumentationURL: check.DocumentationURL,
+		Success:          passes,
 		// FIXME: need to fix the tests before adding this back
 		//Details: details,
 	}


### PR DESCRIPTION
This PR fixes #854

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

Custom check categories already work, but the "more info" links in the dashboard are still hardcoded to `polaris.docs.fairwinds.com/checks/<category>`. So if you make a custom category like `Business`, every link points at a Fairwinds docs page that doesn't exist. This lets you point those links somewhere real.

### What changes did you make?

Added an optional `docURL` field to a check. When it's set, the dashboard uses it for that check's more-info link and for the category's "Refer to the Polaris documentation" link. When it's empty you get the existing Fairwinds link, so nothing changes for anyone who doesn't set it.

The field lands on `SchemaCheck`, flows through to `ResultMessage` in `makeResult`, and two small dashboard helpers (`getResultDocumentationLink`, `getCategoryDocumentationLink`) fall back to the old `getCategoryLink` when it's unset.

Example custom check:

```yaml
customChecks:
  myBusinessCheck:
    category: Business
    docURL: https://docs.internal.example.com/checks/business
    successMessage: Looks good
    failureMessage: Fix it
    # ...schema...
```

Added helper tests in `pkg/dashboard` covering both paths (custom URL when set, default Fairwinds link when unset), and documented the option in `docs/customization/custom-checks.md`. `go build ./...` passes and so do the `pkg/config`, `pkg/validator`, and `pkg/dashboard` tests.

### What alternative solution should we consider, if any?

Could scope `docURL` to the category level instead of the check, but checks are where custom config already lives, so keeping it on the check felt more natural and stays backward compatible.
