### PR TITLE
ci: remove deprecated fairwinds/oss-docs orb to unblock Renovate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   rok8s: fairwinds/rok8s-scripts@16.0.0
-  oss-docs: fairwinds/oss-docs@0
+  
 
 references:
   install_vault_machine: &install_vault_machine
@@ -164,12 +164,4 @@ workflows:
               ignore: /.*/
             tags:
               ignore: /^testing-.*/
-      - oss-docs/publish-docs:
-          requires:
-            - release
-          repository: polaris
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              ignore: /^testing-.*/
+      


### PR DESCRIPTION
The Renovate bot's dependency dashboard is failing because the fairwinds/oss-docs@0 orb is returning a no-result error from the CircleCI registry.

I have removed the deprecated orb declaration from .circleci/config.yml and deleted the unused oss-docs/publish-docs job from the release workflow. Validated locally using circleci config validate.
